### PR TITLE
Updated spunky to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,10 @@
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0",
     "redux-thunk": "^2.2.0",
-    "spunky": "^1.0.1"
+    "spunky": "^1.1.0"
   },
   "scripts": {
-    "start":
-      "concurrently -r \"yarn run start-react\" \"wait-on http://localhost:3000/ && yarn run start-electron\" --kill-others --success first",
+    "start": "concurrently -r \"yarn run start-react\" \"wait-on http://localhost:3000/ && yarn run start-electron\" --kill-others --success first",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
     "start-react": "cross-env BROWSER=none react-app-rewired start",
@@ -41,8 +40,7 @@
     "dist": "yarn run build && electron-builder",
     "clean": "rimraf build dist",
     "clean-neon-js": "rimraf node_modules/neon-js/src",
-    "postinstall":
-      "electron-builder install-app-deps && electron-rebuild --force && yarn run clean-neon-js"
+    "postinstall": "electron-builder install-app-deps && electron-rebuild --force && yarn run clean-neon-js"
   },
   "devDependencies": {
     "autoprefixer": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7362,9 +7362,9 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-spunky@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/spunky/-/spunky-1.0.1.tgz#0189d22d15e4d0b9e8631ebfdcef07dd016fffee"
+spunky@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/spunky/-/spunky-1.1.0.tgz#f1c69c7e50b2f65c7b603bc7b71d5f7abb1b666e"
   dependencies:
     lodash "^4.17.5"
     react-redux "^5.0.6"


### PR DESCRIPTION
This updates the spunky package to 1.1.0.  It doesn't have any change in functionality, it just is a change in how the underlying package is built to prevent running into duplicate babel-polyfill issues.