### PR TITLE
Removed flow syntax

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -1,4 +1,3 @@
-// @flow
 import { wallet } from 'neon-js';
 import { createActions } from 'spunky';
 

--- a/src/hocs/withAuthChange.js
+++ b/src/hocs/withAuthChange.js
@@ -1,26 +1,21 @@
-// @flow
 import React from 'react';
 import { omit } from 'lodash';
 import { compose } from 'recompose';
-import { withData, withProgress, type Progress } from 'spunky';
+import { withData, withProgress } from 'spunky';
 
 import authActions from '../actions/authActions';
-
-type Props = {
-  [key: string]: any
-};
 
 const DATA_PROP = '__authData__';
 const PROGRESS_PROP = '__authProgress__';
 
-export default function withAuthChange(progress: Progress, callback: Function) {
+export default function withAuthChange(progress, callback) {
   const mapDataToProps = (data) => ({
     [DATA_PROP]: data
   });
 
-  return (Component: Class<React.Component<*>>) => {
-    class WrappedComponent extends React.Component<Props> {
-      componentWillReceiveProps(nextProps: Props) {
+  return (Component) => {
+    class WrappedComponent extends React.Component {
+      componentWillReceiveProps(nextProps) {
         if (this.props[PROGRESS_PROP] !== progress && nextProps[PROGRESS_PROP] === progress) {
           callback(nextProps[DATA_PROP], omit(nextProps, DATA_PROP, PROGRESS_PROP));
         }


### PR DESCRIPTION
If we want to use flow, we should do it all in one go.  I accidentally left some flow syntax in a couple spots even though we otherwise haven't enabled it for this app.