### PR TITLE
Added handling to clean request queue on navigation

### DIFF
--- a/src/actions/requestsActions.js
+++ b/src/actions/requestsActions.js
@@ -1,5 +1,7 @@
 export const ENQUEUE_REQUEST = 'ENQUEUE_REQUEST';
 export const DEQUEUE_REQUEST = 'DEQUEUE_REQUEST';
+export const EMPTY_REQUESTS = 'EMPTY_REQUESTS';
 
 export const enqueue = (request) => ({ type: ENQUEUE_REQUEST, request });
 export const dequeue = (id) => ({ type: DEQUEUE_REQUEST, id });
+export const empty = () => ({ type: EMPTY_REQUESTS });

--- a/src/components/DAppContainer/DAppContainer.js
+++ b/src/components/DAppContainer/DAppContainer.js
@@ -9,7 +9,8 @@ export default class DAppContainer extends React.Component {
   static propTypes = {
     src: string.isRequired,
     enqueue: func.isRequired,
-    dequeue: func.isRequired
+    dequeue: func.isRequired,
+    empty: func.isRequired
   };
 
   componentDidMount() {
@@ -20,6 +21,9 @@ export default class DAppContainer extends React.Component {
   componentWillUnmount() {
     this.webview.removeEventListener('console-message', this.handleConsoleMessage);
     this.webview.removeEventListener('ipc-message', this.handleIPCMessage);
+
+    // remove any pending requests from the queue
+    this.props.empty();
   }
 
   render() {

--- a/src/components/DAppContainer/index.js
+++ b/src/components/DAppContainer/index.js
@@ -4,11 +4,12 @@ import { withData } from 'spunky';
 
 import DAppContainer from './DAppContainer';
 import nameServiceActions from '../../actions/nameServiceActions';
-import { enqueue, dequeue } from '../../actions/requestsActions';
+import { enqueue, dequeue, empty } from '../../actions/requestsActions';
 
 const mapDispatchToProps = (dispatch) => ({
   enqueue: (request) => dispatch(enqueue(request)),
-  dequeue: (id) => dispatch(dequeue(id))
+  dequeue: (id) => dispatch(dequeue(id)),
+  empty: () => dispatch(empty())
 });
 
 const mapNameServiceDataToProps = (data) => ({

--- a/src/reducers/requestsReducer.js
+++ b/src/reducers/requestsReducer.js
@@ -1,6 +1,6 @@
 import { findIndex } from 'lodash';
 
-import { ENQUEUE_REQUEST, DEQUEUE_REQUEST } from '../actions/requestsActions';
+import { ENQUEUE_REQUEST, DEQUEUE_REQUEST, EMPTY_REQUESTS } from '../actions/requestsActions';
 
 const initialState = [];
 
@@ -27,6 +27,8 @@ export default function requestsReducer(state = initialState, action) {
       return enqueue(state, action.request);
     case DEQUEUE_REQUEST:
       return dequeue(state, action.id);
+    case EMPTY_REQUESTS:
+      return initialState;
     default:
       return state;
   }


### PR DESCRIPTION
Fixes #35.

This cleans the request queue up so that any outstanding requests do not get processed the next time the user returns to the dapp page.  I think there's still opportunity for improvement here long term, but I want to wait until we make more directions around the browser, if/when we'll add tabs, etc.)