### PR TITLE
Added autofocus functionality to confirm modal's confirm button

### DIFF
--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -5,48 +5,60 @@ import { noop } from 'lodash';
 
 import Modal from '../Modal';
 import Button from '../Forms/Button';
-import image from '../../images/modal-request-icon.png';
+import defaultImage from '../../images/modal-request-icon.png';
 import styles from './Confirm.scss';
 
-export default function SampleConfirm(props) {
-  return (
-    <Modal className={styles.confirm}>
-      <div className={styles.media}>
-        <img src={props.image} width="200" alt="Icon" />
-      </div>
-      <div className={styles.content}>
-        <h4>{props.title}</h4>
-        <div>
-          {props.children}
+export default class SampleConfirm extends React.Component {
+  static propTypes = {
+    children: node,
+    title: string.isRequired,
+    image: string,
+    confirmLabel: string,
+    cancelLabel: string,
+    onConfirm: func,
+    onCancel: func
+  };
+
+  static defaultProps = {
+    children: null,
+    image: defaultImage,
+    confirmLabel: 'OK',
+    cancelLabel: 'Cancel',
+    onConfirm: noop,
+    onCancel: noop
+  };
+
+  componentDidMount() {
+    this.confirm.focus();
+  }
+
+  render() {
+    const { image, title, confirmLabel, cancelLabel, onConfirm, onCancel, children } = this.props;
+
+    return (
+      <Modal className={styles.confirm}>
+        <div className={styles.media}>
+          <img src={image} width="200" alt="Icon" />
         </div>
-        <div className={styles.actions}>
-          <Button className={styles.action} onClick={props.onConfirm} >
-            {props.confirmLabel}
-          </Button>
-          <Button className={classNames(styles.action, styles.cancel)} onClick={props.onCancel}>
-            {props.cancelLabel}
-          </Button>
+        <div className={styles.content}>
+          <h4>{title}</h4>
+          <div>
+            {children}
+          </div>
+          <div className={styles.actions}>
+            <Button className={styles.action} ref={this.registerRef('confirm')} onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+            <Button className={classNames(styles.action, styles.cancel)} onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+          </div>
         </div>
-      </div>
-    </Modal>
-  );
+      </Modal>
+    );
+  }
+
+  registerRef = (name) => {
+    return (el) => { this[name] = el; };
+  }
 }
-
-SampleConfirm.propTypes = {
-  children: node,
-  title: string.isRequired,
-  image: string,
-  confirmLabel: string,
-  cancelLabel: string,
-  onConfirm: func,
-  onCancel: func
-};
-
-SampleConfirm.defaultProps = {
-  children: null,
-  image,
-  confirmLabel: 'OK',
-  cancelLabel: 'Cancel',
-  onConfirm: noop,
-  onCancel: noop
-};

--- a/src/components/Forms/Button/Button.js
+++ b/src/components/Forms/Button/Button.js
@@ -4,10 +4,28 @@ import { string } from 'prop-types';
 
 import styles from './Button.scss';
 
-export default function Button(props) {
-  return (
-    <button {...props} className={classNames(styles.button, props.className)} />
-  );
+export default class Button extends React.Component {
+  render() {
+    return (
+      <button
+        {...this.props}
+        ref={this.registerRef}
+        className={classNames(styles.button, this.props.className)}
+      />
+    );
+  }
+
+  registerRef = (el) => {
+    this.button = el;
+  }
+
+  focus = () => {
+    this.button.focus();
+  }
+
+  blur = () => {
+    this.button.blur();
+  }
 }
 
 Button.propTypes = {


### PR DESCRIPTION
Previously, if the user clicked on a button that opens a confirm modal then pressed enter, they would end up clicking on the original button again, opening another confirm modal on top of the first one.  This change makes it so the confirm modal's confirm button automatically takes focus, meaning that the user pressing enter will confirm the action.