### PR TITLE
Replace remote check with electron mock

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -1,7 +1,20 @@
+const { noop } = require('lodash');
+
 module.exports = {
   app: {
     getPath: () => {
       return '/tmp';
+    }
+  },
+
+  remote: {
+    BrowserWindow: {
+      getFocusedWindow: () => ({
+        minimize: noop,
+        maximize: noop,
+        unmaximize: noop,
+        isMaximized: noop
+      })
     }
   }
 };

--- a/src/components/AuthenticatedLayout/AddressBar/AddressBar.js
+++ b/src/components/AuthenticatedLayout/AddressBar/AddressBar.js
@@ -74,13 +74,12 @@ class AddressBar extends React.Component {
   };
 
   handleMinimizeWindow = () => {
-    if (!remote) return;
     remote.BrowserWindow.getFocusedWindow().minimize();
   };
 
   handleResizeWindow = () => {
-    if (!remote) return;
     const win = remote.BrowserWindow.getFocusedWindow();
+
     if (win.isMaximized()) {
       win.unmaximize();
     } else {
@@ -89,12 +88,10 @@ class AddressBar extends React.Component {
   };
 
   handleCloseWindow = () => {
-    if (!remote) return;
     remote.BrowserWindow.getFocusedWindow().close();
   };
 
   updateIsMax = () => {
-    if (!remote) return;
     const win = remote.BrowserWindow.getFocusedWindow();
     if (win) {
       this.setState({ isMaximized: win.isMaximized() });


### PR DESCRIPTION
This just cleans up a check for `remote` that was needed for test purposes.  Adding mocks lets us remove these checks.