### PR TITLE
Move settings button to the left menu

### DIFF
--- a/src/components/AuthenticatedLayout/ButtonBar/ButtonBar.js
+++ b/src/components/AuthenticatedLayout/ButtonBar/ButtonBar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
 import { remote } from 'electron';
 
 import Icon from '../../Icon';

--- a/src/components/AuthenticatedLayout/ButtonBar/ButtonBar.js
+++ b/src/components/AuthenticatedLayout/ButtonBar/ButtonBar.js
@@ -25,9 +25,6 @@ export default class ButtonBar extends React.Component {
         <button>
           <Icon name="notifications" />
         </button>
-        <NavLink to="/settings">
-          <Icon name="settings" />
-        </NavLink>
         {this.renderWindowIcons()}
       </div>
     );

--- a/src/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -41,6 +41,13 @@ export default class Navigation extends React.Component {
             </NavLink>
           </li>
           <li>
+            <NavLink exact to="/settings">
+              <Tooltip id="settings" overlay="Settings">
+                <Icon name="settings" aria-describedby="settings" />
+              </Tooltip>
+            </NavLink>
+          </li>
+          <li>
             <NavLink exact to="/logout">
               <Tooltip id="logout" overlay="Logout">
                 <Icon name="logout" aria-describedby="logout" />


### PR DESCRIPTION
At the hackathon some users were looking for the Settings button on the left menu. Since there are no page-specific settings right now, it makes sense to move it to the left menu.

https://github.com/nos/client/issues/87

Before:
<img width="774" alt="screen shot 2018-04-19 at 12 23 44 am" src="https://user-images.githubusercontent.com/2775497/38938203-57b1edaa-4368-11e8-8105-9fd8184ad491.png">

After:
<img width="774" alt="screen shot 2018-04-19 at 12 23 29 am" src="https://user-images.githubusercontent.com/2775497/38938255-717e409e-4368-11e8-964f-391817b34d5b.png">

