### PR TITLE
feat(register): save the new account to an already existing Wallet file

### DIFF
--- a/src/components/Register/AccountDetails/SaveAccount/SaveAccount.js
+++ b/src/components/Register/AccountDetails/SaveAccount/SaveAccount.js
@@ -100,7 +100,7 @@ export default class SaveAccount extends React.Component {
       return;
     }
 
-    const newAccount = new wallet.Account({ ...account, label });
+    const newAccount = new wallet.Account({ ...account, label, isDefault: true });
     const newWallet = new wallet.Wallet({ accounts: [newAccount] });
     await this.save(filename, newWallet);
   }

--- a/src/components/Register/AccountDetails/SaveAccount/SaveAccount.scss
+++ b/src/components/Register/AccountDetails/SaveAccount/SaveAccount.scss
@@ -5,15 +5,21 @@
 }
 
 .saveButtons {
-  .button {
-    width: 49%;
-    margin: 0 0 16px 0px;
-  }
+  display: flex;
+  align-items: center;
+  align-content: stretch;
+  flex-wrap: nowrap;
+  padding-bottom: 16px;
 
-  #buttonNew {
-    float: left;
-  }
-  #buttonAdd {
-    float: right;
+  .button {
+  flex: 1;
+
+    &:first-child {
+      margin-right: 8px;
+    }
+
+    &:last-child {
+      margin-left: 8px;
+    }
   }
 }

--- a/src/components/Register/AccountDetails/SaveAccount/SaveAccount.scss
+++ b/src/components/Register/AccountDetails/SaveAccount/SaveAccount.scss
@@ -1,14 +1,19 @@
 .saveAccount {
-  display: flex;
-  align-items: flex-end;
-  flex-wrap: nowrap;
-
   .label {
     flex: 1 1 auto;
   }
+}
 
+.saveButtons {
   .button {
-    flex: 0 0 auto;
-    margin: 0 0 16px 16px;
+    width: 49%;
+    margin: 0 0 16px 0px;
+  }
+
+  #buttonNew {
+    float: left;
+  }
+  #buttonAdd {
+    float: right;
   }
 }

--- a/src/util/accountToNEP6.js
+++ b/src/util/accountToNEP6.js
@@ -1,8 +1,0 @@
-import { wallet } from '@cityofzion/neon-js';
-
-export default function accountToNEP6({ address, key, label = address, isDefault = true }) {
-  const newAccount = new wallet.Account({ address, key, label, isDefault });
-  const newWallet = new wallet.Wallet({ accounts: [newAccount] });
-
-  return newWallet.export();
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

## Description
<!--- Describe your changes in detail -->
This PR adds the possibility for the users, after creating a new account via the client, to choose between saving this account as a new NP6 wallet (the only option available at the moment) or to add it to an already existing wallet (the feature this PR adds).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the users, after creating a new account via the registration page, can only choose to export the account by creating a new NP6. I think it would be nice to be able to add the account to a wallet of their choices.
Before: Only one button 'Save' was available on the account details page.
Now: Two buttons are available 'Save as new NEP6 Wallet' on the account details page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with:
- A wallet with 1+ accounts -> OK
- A wallet with 1 account -> OK
- A wallet with no account -> OK
- An empty file -> Error message pops-up (OK)

## Screenshots (if appropriate):
![feat register](https://user-images.githubusercontent.com/28727587/39312696-7a653ec0-4970-11e8-9434-f28b58d7f017.jpeg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
