### PR TITLE
feat(public):add support for splash screen on app load

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -41,9 +41,16 @@ function createWindow() {
   // As it is light weight it will load almost instantly and before mainWindow
   splashWindow = new BrowserWindow({ width: 1250, height: 700, show: true });
 
-  process.env.NODE_ENV === 'production' ?
-    splashWindow.loadURL(`file://${process.env.PUBLIC_URL}/splash.html`) :
-    splashWindow.loadURL(`file://${__dirname}/splash.html`)
+  splashWindow.loadURL(
+    url.format({
+      pathname: path.join(
+        process.env.NODE_ENV === 'production' ? process.env.PUBLIC_URL : __dirname,
+        'splash.html'
+      ),
+      protocol: 'file:',
+      slashes: true
+    })
+  );
 
   mainWindow.loadURL(
     process.env.ELECTRON_START_URL ||

--- a/public/electron.js
+++ b/public/electron.js
@@ -22,6 +22,7 @@ function installExtensions() {
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;
+let splashWindow;
 
 const isMac = process.platform === 'darwin';
 
@@ -29,12 +30,24 @@ function createWindow() {
   const framelessConfig = isMac ? { titleBarStyle: 'hidden' } : { frame: false };
 
   mainWindow = new BrowserWindow(
-    Object.assign({ width: 1250, height: 700 }, framelessConfig)
+    Object.assign({ width: 1250, height: 700, show: false }, framelessConfig)
+  );
+
+  splashWindow = new BrowserWindow(
+    { width: 1250, height: 700, show: true }
   );
 
   if (isDev) {
     mainWindow.webContents.openDevTools();
   }
+
+  splashWindow.loadURL(
+    url.format({
+      pathname: path.join(__dirname, '../build/splash.html'),
+      protocol: 'file:',
+      slashes: true
+    })
+  );
 
   mainWindow.loadURL(
     process.env.ELECTRON_START_URL ||
@@ -45,6 +58,12 @@ function createWindow() {
       })
   );
 
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.show();
+    splashWindow.destroy();
+  });
+
+  // if main window is ready to show, then destroy the splash window and show up the main window
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/public/electron.js
+++ b/public/electron.js
@@ -33,21 +33,17 @@ function createWindow() {
     Object.assign({ width: 1250, height: 700, show: false }, framelessConfig)
   );
 
-  splashWindow = new BrowserWindow(
-    { width: 1250, height: 700, show: true }
-  );
-
   if (isDev) {
     mainWindow.webContents.openDevTools();
   }
 
-  splashWindow.loadURL(
-    url.format({
-      pathname: path.join(__dirname, '../build/splash.html'),
-      protocol: 'file:',
-      slashes: true
-    })
-  );
+  // splashWindow is shown while mainWindow is loading hidden
+  // As it is light weight it will load almost instantly and before mainWindow
+  splashWindow = new BrowserWindow({ width: 1250, height: 700, show: true });
+
+  process.env.NODE_ENV === 'production' ?
+    splashWindow.loadURL(`file://${process.env.PUBLIC_URL}/splash.html`) :
+    splashWindow.loadURL(`file://${__dirname}/splash.html`)
 
   mainWindow.loadURL(
     process.env.ELECTRON_START_URL ||
@@ -58,12 +54,13 @@ function createWindow() {
       })
   );
 
+  // When mainWindow finishes loading, then show
+  // the mainWindow and desotry the splashWindow.
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow.show();
     splashWindow.destroy();
   });
 
-  // if main window is ready to show, then destroy the splash window and show up the main window
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/public/splash.html
+++ b/public/splash.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <style>
+        .bg {
+          -webkit-app-region: drag;
+          position: absolute;
+          background: radial-gradient(#fff, #c1c1c1);
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          background-size: contain;
+        }
+
+        .loader {
+          border: 18px solid rgb(118, 184, 86);
+          border-radius: 50%;
+          border-top: 18px solid rgb(185, 208, 83);
+          width: 90px;
+          height: 90px;
+          -webkit-animation: spin 1.2s linear infinite; /* Safari */
+          animation: spin 1.2s linear infinite;
+        }
+
+        /* Safari */
+        @-webkit-keyframes spin {
+          0% { -webkit-transform: rotate(0deg); }
+          100% { -webkit-transform: rotate(360deg); }
+        }
+
+        @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+
+        .cn {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+    </style>
+
+  </head>
+  <body>
+
+    <div class="bg cn"><div class="loader"></div></div>
+
+  </body>
+</html>


### PR DESCRIPTION
Including a simple loader in the form-ish(-ish) of nOS logo. Further work to improve loader design would be desirable.

## Description
There were 2 main changes in the code:

public/electron.js (modification):
- mainWindow does not open as default anymore
- splashWindow was included to be quickly loaded while waiting for mainWindow
- when mainWindow finishes loading, capture by the "did-finish-load" event, then show mainWindow and destroys splashWindow

public/splash.html (new file):
- HTML code of the splash screen
- contains simple a loader

## Motivation and Context
Related to issue #70 

## How Has This Been Tested?
No tests have been added besides running the ones currently available through `yarn run test`.

## Screenshots (if appropriate):
<img width="660" alt="nos_splash_loader" src="https://user-images.githubusercontent.com/5572680/39455326-ba938bfe-4cd7-11e8-9e44-d62f092ef8ce.png">


## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
