### PR TITLE
chore(forms): disabled register button if no text is entered and pass…

### DIFF
--- a/src/components/Login/LoginFormPassphrase/LoginFormPassphrase.js
+++ b/src/components/Login/LoginFormPassphrase/LoginFormPassphrase.js
@@ -51,7 +51,7 @@ export default class LoginFormWIF extends React.Component {
         />
 
         <div className={styles.actions}>
-          <Button type="submit" disabled={disabled}>Login</Button>
+          <Button type="submit" disabled={disabled || !this.isValid()}>Login</Button>
           <span className={styles.register}>
             New to NEO?{' '}
             <Link to="/register">Create an account</Link>
@@ -74,5 +74,9 @@ export default class LoginFormWIF extends React.Component {
 
     event.preventDefault();
     onLogin({ passphrase, encryptedWIF });
+  }
+
+  isValid = () => {
+    return this.props.passphrase !== '' && this.props.encryptedWIF !== '';
   }
 }

--- a/src/components/Login/LoginFormWIF/LoginFormWIF.js
+++ b/src/components/Login/LoginFormWIF/LoginFormWIF.js
@@ -37,7 +37,7 @@ export default class LoginFormWIF extends React.Component {
         />
 
         <div className={styles.actions}>
-          <Button type="submit" disabled={disabled}>Login</Button>
+          <Button type="submit" disabled={disabled || !this.isValid()}>Login</Button>
         </div>
       </form>
     );
@@ -52,5 +52,9 @@ export default class LoginFormWIF extends React.Component {
 
     event.preventDefault();
     onLogin({ wif });
+  }
+
+  isValid = () => {
+    return this.props.wif !== '';
   }
 }

--- a/src/components/Register/RegisterForm/RegisterForm.js
+++ b/src/components/Register/RegisterForm/RegisterForm.js
@@ -51,7 +51,7 @@ export default class RegisterForm extends React.Component {
         />
 
         <div className={styles.actions}>
-          <Button type="submit" disabled={disabled}>Register</Button>
+          <Button type="submit" disabled={disabled || !this.isValid()}>Register</Button>
           <span className={styles.login}>
             Already have an account?{' '}
             <Link to="/login">Login</Link>
@@ -70,10 +70,13 @@ export default class RegisterForm extends React.Component {
   }
 
   handleRegister = (event) => {
-    event.preventDefault();
+    const { passphrase, passphraseConfirmation, onRegister } = this.props;
 
-    // TODO: ensure passphrases match
-    const { passphrase, passphraseConfirmation } = this.props;
-    return this.props.onRegister({ passphrase, passphraseConfirmation });
+    event.preventDefault();
+    onRegister({ passphrase, passphraseConfirmation });
+  }
+
+  isValid = () => {
+    return this.props.passphrase !== '' && this.props.passphrase === this.props.passphraseConfirmation;
   }
 }


### PR DESCRIPTION
…phrases don't match  & disabled login buttons if no text is entered

<!--- Provide a general summary of your changes in the Title above -->

<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

## Description
<!--- Describe your changes in detail -->
Some UX changes on the register & login pages.

The register button on the Register page is now disabled if:
- The passphrases don't match
- The inputs are empty

The login button on the Login with passphrase page is now disabled if:
- The inputs are empty

The login button on the Login with WIF page is now disabled if:
- The input is empty


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
<!--- If it fixes an open issue, please link to the issue here. -->
I saw a //TODO in RegisterForm.js saying that we need to make sure the passphrases matches so I decided to fix that.
I took the opportunity to improve the UX a bit on the register and login pages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested manually on the 3 files I modified

## Screenshots (if appropriate):
![example](https://user-images.githubusercontent.com/28727587/39592577-73438efc-4f07-11e8-881c-6c0cf596f423.jpeg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
