### PR TITLE
Fixed input focus not working on register screen

### DIFF
--- a/src/components/AuthenticatedLayout/AuthenticatedLayout.scss
+++ b/src/components/AuthenticatedLayout/AuthenticatedLayout.scss
@@ -50,6 +50,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    -webkit-app-region: no-drag;
 
     .content {
       box-sizing: border-box;

--- a/src/components/Login/Login.scss
+++ b/src/components/Login/Login.scss
@@ -1,8 +1,8 @@
 .login {
-  -webkit-app-region: no-drag;
   max-width: 450px;
   margin: 0 auto;
   padding: 20px;
+  -webkit-app-region: no-drag;
 
   .logo {
     display: block;

--- a/src/components/Register/Register.scss
+++ b/src/components/Register/Register.scss
@@ -2,6 +2,7 @@
   max-width: 550px;
   margin: 0 auto;
   padding: 20px;
+  -webkit-app-region: no-drag;
 
   .logo {
     display: block;


### PR DESCRIPTION
## Description
This fixes focusing on inputs in the register screen.

## Motivation and Context
The window drag and drop functionality is preventing users on Windows & Linux from focusing on the inputs in the register screen.  The cause is `-webkit-app-region: drag` eating mouse related events.  According to [this electron issue](https://github.com/electron/electron/issues/1354), the solution is to set `-webkit-app-region: no-drag` on any child elements that should accept normal mouse events.

## How Has This Been Tested?
I pinged two devs in the Discord `#develop` channel to ask them to try this branch.  One Windows user said it's fixed, another Gentoo Linux user said it's fixed.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
Fixes #124