### PR TITLE
chore(api): return full result object instead of script

### DIFF
--- a/src/browser/actions/makeTestInvokeActions.js
+++ b/src/browser/actions/makeTestInvokeActions.js
@@ -24,7 +24,7 @@ const testInvoke = async ({ net, scriptHash, operation, args }) => {
   const script = createScript(scriptHash, operation, args);
   const { result } = await rpc.Query.invokeScript(script).execute(endpoint);
 
-  return result.script;
+  return result;
 };
 
 export default function makeTestInvokeActions(sessionId, requestId) {

--- a/src/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
+++ b/src/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { any, objectOf, func } from 'prop-types';
+import { func } from 'prop-types';
+
+import testInvokeShape from '../../../shapes/testInvokeShape';
 
 export default class TestInvoke extends React.Component {
   static propTypes = {
-    result: objectOf(any).isRequired,
+    result: testInvokeShape.isRequired,
     onResolve: func.isRequired
   };
 

--- a/src/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
+++ b/src/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { string, func } from 'prop-types';
+import { any, objectOf, func } from 'prop-types';
 
 export default class TestInvoke extends React.Component {
   static propTypes = {
-    script: string.isRequired,
+    result: objectOf(any).isRequired,
     onResolve: func.isRequired
   };
 
   componentDidMount() {
-    this.props.onResolve(this.props.script);
+    this.props.onResolve(this.props.result);
   }
 
   render() {

--- a/src/browser/components/RequestsProcessor/TestInvoke/index.js
+++ b/src/browser/components/RequestsProcessor/TestInvoke/index.js
@@ -8,7 +8,7 @@ import withClean from '../../../hocs/withClean';
 import withNullLoader from '../../../hocs/withNullLoader';
 import withRejectMessage from '../../../hocs/withRejectMessage';
 
-const mapInvokeDataToProps = (script) => ({ script });
+const mapInvokeDataToProps = (result) => ({ result });
 
 export default function makeStorageComponent(testInvokeActions) {
   return compose(

--- a/src/browser/shapes/resultStackShape.js
+++ b/src/browser/shapes/resultStackShape.js
@@ -1,0 +1,6 @@
+import { string, shape } from 'prop-types';
+
+export default shape({
+  type: string.isRequired,
+  value: string.isRequired
+});

--- a/src/browser/shapes/testInvokeShape.js
+++ b/src/browser/shapes/testInvokeShape.js
@@ -1,0 +1,10 @@
+import { string, arrayOf, shape } from 'prop-types';
+
+import stackShape from './resultStackShape';
+
+export default shape({
+  script: string.isRequired,
+  state: string.isRequired,
+  gas_consumed: string.isRequired,
+  stack: arrayOf(stackShape).isRequired
+});


### PR DESCRIPTION
## Description
testInvoke now returns the full result object instead of just the script.

## Motivation and Context
* Give developers more info on their invocations (gas consumed)
* Allow developers that want to leverage the actual calculated result to do so

## How Has This Been Tested?
* Fired up the starter-kit, testInvoke now returns the result object. Validated that childs like `gas_consumed` and `stack` were present.

## Screenshots (if appropriate):
![screenshot 2018-05-09 09 50 03](https://user-images.githubusercontent.com/19305608/39802575-b1e85d70-536e-11e8-9c0a-2dd315069b6e.png)


## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues

Fixes #
