### PR TITLE
Quit app when all windows are closed

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -106,11 +106,7 @@ app.on('ready', () => {
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (isMac) {
-    app.quit();
-  }
+  app.quit();
 });
 
 app.on('activate', () => {


### PR DESCRIPTION
## Description
The logic surrounding our app quit logic was backwards, and it wasn't properly quitting for non-mac platforms.

## Motivation and Context
The app should quit when all windows are closed.  When the `isMac` variable was introduced, the logic here was accidentally inverted.  The intention was for the app to continue running when all windows are closed on Mac, but to quit when all windows are closed on all other platforms.  What was actually happening is that the app would quit on Mac, but continue running on all other platforms.

The fix for the above is to negate the `isMac` check in the conditional.  However, with this change I'm actually introducing logic for us to quit the app any time the window is closed.  There is no reason for us to keep it running on Mac, especially since we don't have a menu option to reopen the window once it closes.

## How Has This Been Tested?
I quit the app.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
N/A