### PR TITLE
Fixed React prop warnings in tests

### DIFF
--- a/__tests__/components/App/Routes.test.js
+++ b/__tests__/components/App/Routes.test.js
@@ -70,7 +70,15 @@ describe('<Routes />', () => {
         spunky: { auth: authenticatedState },
         browser: {
           activeSessionId: '1',
-          tabs: { 1: { title: 'Welcome to nOS', target: 'nos://nos.neo', loading: false } }
+          tabs: {
+            1: {
+              title: 'Welcome to nOS',
+              target: 'nos://nos.neo',
+              loading: false,
+              requestCount: 1,
+              addressBarEntry: true
+            }
+          }
         }
       });
       expect(wrapper.find(Browser).exists()).toBe(true);


### PR DESCRIPTION
## Description
This fixes React missing prop warnings.  The shape of the data in the browser reducer changed, but I neglected to update a test that stubs that data.

## Motivation and Context
We shouldn't have test warnings, it implies our tests are not set up properly.

## How Has This Been Tested?
`yarn test`

## Screenshots (if appropriate):
<img width="581" alt="screen shot 2018-05-26 at 9 39 26 am" src="https://user-images.githubusercontent.com/169093/40577851-b4d9a1ee-60c8-11e8-95a8-10e55d65068e.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
N/A