### PR TITLE
chore(dev): change default port from 3000 to 4000

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "what-input": "5.0.5"
   },
   "scripts": {
-    "start": "concurrently -r \"yarn run start-react\" \"wait-on http://localhost:3000/ && yarn run start-electron\" --kill-others --success first",
+    "start": "concurrently -r \"yarn run start-react\" \"wait-on http://localhost:4000/ && yarn run start-electron\" --kill-others --success first",
     "build": "react-app-rewired build",
     "pretest": "yarn run lint",
     "test": "react-app-rewired test --env=jsdom --testMatch \"**/__tests__/**/*.test.{js,jsx,mjs}\" --setupTestFrameworkScriptFile \"./__tests__/setupTests.js\"",
-    "start-react": "cross-env BROWSER=none react-app-rewired start",
-    "start-electron": "cross-env ELECTRON_START_URL=http://localhost:3000/ electron .",
+    "start-react": "cross-env PORT=4000 BROWSER=none react-app-rewired start",
+    "start-electron": "cross-env ELECTRON_START_URL=http://localhost:4000/ electron .",
     "pack": "yarn run build && electron-builder --dir",
     "dist": "yarn run build && cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=true electron-builder",
     "lint": "eslint --env browser,node,server --ext .jsx,.js --color .",


### PR DESCRIPTION
## Description
This just changes the webpack dev server port from 3000 to 4000.

## Motivation and Context
I keep having a lot of context switching (taking services down and up) between other work and nOS work.  There's some added overhead of having to switch things every time I want to work on nOS or work on something else.

It also seems like this change should not really have an impact on anyone else, so it feels like something that will make my life easier without negatively impacting anyone.  (Let me know if I'm wrong though!)

## How Has This Been Tested?
`yarn start` ran & loaded nOS as expected.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
N/A