### PR TITLE
chore(body): set background-color to content-bg

### DIFF
--- a/src/root/stylesheets/global.scss
+++ b/src/root/stylesheets/global.scss
@@ -9,7 +9,7 @@
 body {
   margin: 0;
   padding: 0;
-  background: linear-gradient(to bottom right, #b8d432, #5bb947);
+  background: $content-bg-color;
   color: #58585a;
 
   font: {


### PR DESCRIPTION
Changed the body background color

## Description
Removed the linear gradient from the body and replaced it with the color handled by the $content-bg-color variable

## Motivation and Context

I spoke to @mhuggins on discord earlier and he suggested to start with a simple contribution by changing the 'the hideous green background'. 

## How Has This Been Tested?
Since my version of the client does not yet have the fix of the responsive tabs I managed to see the background color by adding multiple tabs that opened the overflow of the client

## Screenshots (if appropriate):
Before:
<img width="640" alt="before the fix" src="https://user-images.githubusercontent.com/14752054/40588121-eabc4c7e-61d8-11e8-9943-795d9fde04e6.png">

After:
<img width="6400" alt="after the fix" src="https://user-images.githubusercontent.com/14752054/40588125-f15eca20-61d8-11e8-86ca-7ec442e23bda.png">

## Types of changes
Changed src/root/stylesheets/global.scss

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
