### PR TITLE
feat(tabs): shortcuts

### DIFF
--- a/src/browser/components/Tabs/Tabs.js
+++ b/src/browser/components/Tabs/Tabs.js
@@ -70,8 +70,10 @@ export default class Tabs extends React.Component {
   }
 
   handleShortcuts = (event) => {
+    const combinationKeyIsPressed = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
+
     // Command + w (close current tab or client)
-    if (event.metaKey && event.key === 'w') {
+    if (combinationKeyIsPressed && event.key === 'w') {
       if (Object.keys(this.props.tabs).length > 1) {
         // Prevent client to quit (default behavior)
         event.preventDefault();
@@ -81,7 +83,7 @@ export default class Tabs extends React.Component {
     }
 
     // Command + t (open new tab)
-    if (event.metaKey && event.key === 't') {
+    if (combinationKeyIsPressed && event.key === 't') {
       event.preventDefault();
       this.props.onOpen();
     }

--- a/src/browser/components/Tabs/Tabs.js
+++ b/src/browser/components/Tabs/Tabs.js
@@ -23,6 +23,14 @@ export default class Tabs extends React.Component {
     setActiveTab: noop
   };
 
+  componentDidMount() {
+    window.addEventListener('keydown', this.handleShortcuts, true);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.handleShortcuts);
+  }
+
   render() {
     return (
       <div className={styles.tabs}>
@@ -59,5 +67,23 @@ export default class Tabs extends React.Component {
     return () => {
       this.props.onClose(sessionId);
     };
+  }
+
+  handleShortcuts = (event) => {
+    // Command + w (close current tab or client)
+    if (event.metaKey && event.key === 'w') {
+      if (Object.keys(this.props.tabs).length > 1) {
+        // Prevent client to quit (default behavior)
+        event.preventDefault();
+        // Only close active tab if there is more than 1 tab added
+        this.props.onClose(this.props.activeSessionId);
+      }
+    }
+
+    // Command + t (open new tab)
+    if (event.metaKey && event.key === 't') {
+      event.preventDefault();
+      this.props.onOpen();
+    }
   }
 }


### PR DESCRIPTION
Solving feature request #191 to add tab control.

## Description
This pull requests adds expected tab control to the nOS client.

## Motivation and Context
Quick opening up tabs and closing current actives ones wasn't supported yet.

## How Has This Been Tested?
Tested on multiple OSX platforms and node environments.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.
- [x] Compliant with Electron best practices https://electronjs.org/docs/tutorial/keyboard-shortcuts

## Closing issues
#191 
