### PR TITLE
feat(tabs): focus address field after adding new tab

### DIFF
--- a/src/browser/components/AddressBar/AddressBar.js
+++ b/src/browser/components/AddressBar/AddressBar.js
@@ -26,6 +26,12 @@ export default class AddressBar extends React.Component {
       this.input.value = this.props.query;
       this.input.blur();
     }
+
+    if (this.props.tabCount > prevProps.tabCount) {
+      // Focus the address field after opening a new tab
+      this.input.value = '';
+      this.input.focus();
+    }
   }
 
   render() {

--- a/src/browser/components/AddressBar/AddressBar.js
+++ b/src/browser/components/AddressBar/AddressBar.js
@@ -31,7 +31,12 @@ export default class AddressBar extends React.Component {
 
     if (this.props.tabCount > prevProps.tabCount) {
       // Focus the address field after opening a new tab
-      this.input.focus();
+      this.input.select();
+    } else if (this.props.tabCount < prevProps.tabCount) {
+      // Blur the address field after closing a tab and make sure the
+      // correspondent address is shown
+      this.input.value = this.props.query;
+      this.input.blur();
     }
   }
 

--- a/src/browser/components/AddressBar/AddressBar.js
+++ b/src/browser/components/AddressBar/AddressBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { func, string } from 'prop-types';
+import { func, number, string } from 'prop-types';
 import { noop } from 'lodash';
 
 import ButtonBar from '../ButtonBar';
@@ -12,12 +12,14 @@ export default class AddressBar extends React.Component {
   static propTypes = {
     className: string,
     query: string,
+    tabCount: number,
     onQuery: func
   };
 
   static defaultProps = {
     className: null,
     query: '',
+    tabCount: 1,
     onQuery: noop
   };
 

--- a/src/browser/components/AddressBar/AddressBar.js
+++ b/src/browser/components/AddressBar/AddressBar.js
@@ -31,7 +31,6 @@ export default class AddressBar extends React.Component {
 
     if (this.props.tabCount > prevProps.tabCount) {
       // Focus the address field after opening a new tab
-      this.input.value = '';
       this.input.focus();
     }
   }

--- a/src/browser/components/AddressBar/index.js
+++ b/src/browser/components/AddressBar/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import AddressBar from './AddressBar';
 
 const mapStateToProps = (state) => {
-  const tabCount = Object.keys(state.browser.tabs).length
+  const tabCount = Object.keys(state.browser.tabs).length;
 
   return { tabCount };
 };

--- a/src/browser/components/AddressBar/index.js
+++ b/src/browser/components/AddressBar/index.js
@@ -1,7 +1,17 @@
-import { withPropsOnChange } from 'recompose';
+import { compose, withPropsOnChange } from 'recompose';
+import { connect } from 'react-redux';
 
 import AddressBar from './AddressBar';
 
-export default withPropsOnChange(['query'], (props) => ({
-  query: props.query.replace(/^(\w+:\/{2,}[\w@:]+)\/$/, '$1') // strip trailing slash from TLD
-}))(AddressBar);
+const mapStateToProps = (state) => {
+  const tabCount = Object.keys(state.browser.tabs).length
+
+  return { tabCount };
+};
+
+export default compose(
+  connect(mapStateToProps),
+  withPropsOnChange(['query'], (props) => ({
+    query: props.query.replace(/^(\w+:\/{2,}[\w@:]+)\/$/, '$1') // strip trailing slash from TLD
+  }))
+)(AddressBar);


### PR DESCRIPTION
## Description
This pull requests makes sure the address field is focussed after adding a new tab to quickly enter your preferred url.

## Motivation and Context
Entering an url takes another manual click in the client; expected default browser behavior after adding a new tab is that the address field is focussed (safari, chrome, etc.).

## How Has This Been Tested?
On OSX with multiple node environments.
Tested with new tabs, closing tabs, re-new tab, etc. (see .gif).

## Screenshots (if appropriate):
![tab-focus](https://user-images.githubusercontent.com/529396/40790914-78158296-64f6-11e8-87ee-93913957ec07.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
#192 