### PR TITLE
Temporarily remove service worker included by CRA

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,16 @@ import 'what-input';
 import 'root/stylesheets/global.scss';
 
 import { Root } from './root';
-import registerServiceWorker from './registerServiceWorker';
+// import registerServiceWorker from './registerServiceWorker';
 
 function render(Component) {
   ReactDOM.render(<Component />, document.getElementById('root'));
 }
 
 render(Root);
-registerServiceWorker();
+
+// TODO: restore this after https://github.com/electron/electron/issues/9705 is fixed
+// registerServiceWorker();
 
 if (module.hot) {
   module.hot.accept('./root', () => {


### PR DESCRIPTION
## Description
The `create-react-app` package includes a service worker to serve assets from local cache.  However, there is a conflict with using the `file:` protocol in conjunction with service workers in electron.

## Motivation and Context
We're running into the issue found here: https://github.com/electron/electron/issues/9705

## How Has This Been Tested?
I asked @DalderupMaurice to try it on Windows.

## Screenshots (if appropriate):
![file protocol unsupported](https://i.imgur.com/lkJbOgI.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
