### PR TITLE
feat(error-page): add error page component

### DIFF
--- a/__tests__/browser/index.test.js
+++ b/__tests__/browser/index.test.js
@@ -5,6 +5,7 @@ import { provideStore, createStore } from 'testHelpers';
 import { Browser } from 'browser';
 
 import DAppContainer from 'browser/components/DAppContainer';
+import Error from 'browser/components/Error';
 import Tab from 'browser/components/Tab';
 
 const initialState = {
@@ -24,6 +25,15 @@ const initialState = {
         addressBarEntry: true,
         loading: false,
         requestCount: 1
+      },
+      'tab-3': {
+        target: 'protocol://error',
+        title: 'nOS Error',
+        addressBarEntry: true,
+        loading: false,
+        requestCount: 1,
+        errorCode: -105,
+        errorDescription: 'NAME_NOT_RESOLVED'
       }
     }
   }
@@ -42,13 +52,14 @@ const openTab = (wrapper, index) => {
 describe('<Browser />', () => {
   it('renders all tabs', () => {
     const wrapper = mountBrowser();
-    expect(wrapper.find(DAppContainer).length).toBe(2);
+    expect(wrapper.find(DAppContainer).length).toBe(3);
   });
 
   it("only marks the activeSessionId's dapp as active", () => {
     const wrapper = mountBrowser();
     expect(wrapper.find(DAppContainer).at(0).prop('active')).toBe(true);
     expect(wrapper.find(DAppContainer).at(1).prop('active')).toBe(false);
+    expect(wrapper.find(DAppContainer).at(2).prop('active')).toBe(false);
   });
 
   it('changes tabs', () => {
@@ -56,12 +67,18 @@ describe('<Browser />', () => {
     openTab(wrapper, 1);
     expect(wrapper.find(Tab).at(0).prop('active')).toBe(false);
     expect(wrapper.find(Tab).at(1).prop('active')).toBe(true);
+    expect(wrapper.find(Tab).at(2).prop('active')).toBe(false);
   });
 
   it('does not remove the webview from the DOM when changing tabs', () => {
     const wrapper = mountBrowser();
-    expect(wrapper.find('webview').length).toBe(2);
+    expect(wrapper.find('webview').length).toBe(3);
     openTab(wrapper, 1);
-    expect(wrapper.find('webview').length).toBe(2);
+    expect(wrapper.find('webview').length).toBe(3);
+  });
+
+  it('hides the webview and shows an error', () => {
+    const wrapper = mountBrowser();
+    expect(wrapper.find(Error).length).toBe(1);
   });
 });

--- a/src/browser/actions/browserActions.js
+++ b/src/browser/actions/browserActions.js
@@ -1,14 +1,20 @@
 export const OPEN_TAB = 'OPEN_TAB';
 export const CLOSE_TAB = 'CLOSE_TAB';
 export const SET_ACTIVE_TAB = 'SET_ACTIVE_TAB';
+export const SET_TAB_ERROR = 'SET_TAB_ERROR';
 export const SET_TAB_TARGET = 'SET_TAB_TARGET';
-export const SET_TAB_TARGET_HTTP_STATUS = 'SET_TAB_TARGET_HTTP_STATUS';
 export const SET_TAB_TITLE = 'SET_TAB_TITLE';
 export const SET_TAB_LOADED = 'SET_TAB_LOADED';
 
 export const openTab = () => ({ type: OPEN_TAB });
 export const closeTab = (sessionId) => ({ type: CLOSE_TAB, sessionId });
 export const setActiveTab = (sessionId) => ({ type: SET_ACTIVE_TAB, sessionId });
+export const setTabError = (sessionId, code, description) => ({
+  type: SET_TAB_ERROR,
+  sessionId,
+  code,
+  description
+});
 export const setTabTarget = (sessionId, target, {
   addressBarEntry = false,
   leavingPage = true
@@ -18,11 +24,6 @@ export const setTabTarget = (sessionId, target, {
   target,
   addressBarEntry, // Differentiates between link clicks and address bar entries
   leavingPage // Differentiates between anchor link clicks on the current page vs. new page loads
-});
-export const setTabTargetHttpStatus = (sessionId, statusCode) => ({
-  type: SET_TAB_TARGET_HTTP_STATUS,
-  sessionId,
-  statusCode // The HTTP status code, e.g. 404 for page not found
 });
 export const setTabTitle = (sessionId, title) => ({ type: SET_TAB_TITLE, sessionId, title });
 export const setTabLoaded = (sessionId, loaded) => ({ type: SET_TAB_LOADED, sessionId, loaded });

--- a/src/browser/actions/browserActions.js
+++ b/src/browser/actions/browserActions.js
@@ -2,6 +2,7 @@ export const OPEN_TAB = 'OPEN_TAB';
 export const CLOSE_TAB = 'CLOSE_TAB';
 export const SET_ACTIVE_TAB = 'SET_ACTIVE_TAB';
 export const SET_TAB_TARGET = 'SET_TAB_TARGET';
+export const SET_TAB_TARGET_HTTP_STATUS = 'SET_TAB_TARGET_HTTP_STATUS';
 export const SET_TAB_TITLE = 'SET_TAB_TITLE';
 export const SET_TAB_LOADED = 'SET_TAB_LOADED';
 
@@ -15,8 +16,13 @@ export const setTabTarget = (sessionId, target, {
   type: SET_TAB_TARGET,
   sessionId,
   target,
-  addressBarEntry, // differentiates between link clicks and address bar entries
-  leavingPage // differentiates between anchor link clicks on the current page vs. new page loads
+  addressBarEntry, // Differentiates between link clicks and address bar entries
+  leavingPage // Differentiates between anchor link clicks on the current page vs. new page loads
+});
+export const setTabTargetHttpStatus = (sessionId, statusCode) => ({
+  type: SET_TAB_TARGET_HTTP_STATUS,
+  sessionId,
+  statusCode // The HTTP status code, e.g. 404 for page not found
 });
 export const setTabTitle = (sessionId, title) => ({ type: SET_TAB_TITLE, sessionId, title });
 export const setTabLoaded = (sessionId, loaded) => ({ type: SET_TAB_LOADED, sessionId, loaded });

--- a/src/browser/components/Browser/Browser.js
+++ b/src/browser/components/Browser/Browser.js
@@ -48,6 +48,8 @@ export default class Browser extends React.Component {
         addressBarEntry={tab.addressBarEntry}
         requestCount={tab.requestCount}
         active={sessionId === this.props.activeSessionId}
+        errorCode={tab.errorCode}
+        errorDescription={tab.errorDescription}
       />
     );
   }

--- a/src/browser/components/DAppContainer/DAppContainer.js
+++ b/src/browser/components/DAppContainer/DAppContainer.js
@@ -4,17 +4,21 @@ import classNames from 'classnames';
 import { shell } from 'electron';
 import { string, bool, number, func } from 'prop-types';
 
+import Error from '../Error';
 import RequestsProcessor from '../RequestsProcessor';
 import styles from './DAppContainer.scss';
 
 export default class DAppContainer extends React.Component {
   static propTypes = {
     className: string,
+    errorCode: number,
+    errorDescription: string,
     sessionId: string.isRequired,
     active: bool.isRequired,
     target: string.isRequired,
     addressBarEntry: bool.isRequired,
     requestCount: number.isRequired,
+    setTabError: func.isRequired,
     setTabTitle: func.isRequired,
     setTabTarget: func.isRequired,
     setTabLoaded: func.isRequired,
@@ -25,7 +29,9 @@ export default class DAppContainer extends React.Component {
   }
 
   static defaultProps = {
-    className: null
+    className: null,
+    errorCode: null,
+    errorDescription: null
   }
 
   componentDidMount() {
@@ -68,11 +74,8 @@ export default class DAppContainer extends React.Component {
 
     return (
       <div className={classNames(styles.dAppContainer, className, { [styles.active]: active })}>
-        <webview
-          ref={this.registerRef}
-          preload={this.getPreloadPath()}
-          style={{ height: '100%' }}
-        />
+        {this.renderWebView()}
+        {this.renderError()}
 
         <RequestsProcessor
           sessionId={sessionId}
@@ -81,6 +84,36 @@ export default class DAppContainer extends React.Component {
           onReject={this.handleReject}
         />
       </div>
+    );
+  }
+
+  renderError() {
+    const { target, errorCode, errorDescription } = this.props;
+
+    // Validate if there is an error code (do not check with ! as the code
+    // could have a negative value)
+    if (errorCode !== null) {
+      return (
+        <Error
+          target={target}
+          code={errorCode}
+          description={errorDescription}
+        />
+      );
+    }
+
+    return null;
+  }
+
+  renderWebView() {
+    const { errorCode } = this.props;
+
+    return (
+      <webview
+        ref={this.registerRef}
+        preload={this.getPreloadPath()}
+        className={classNames(styles.webview, { [styles.hidden]: errorCode !== null })}
+      />
     );
   }
 
@@ -112,9 +145,8 @@ export default class DAppContainer extends React.Component {
     this.props.setTabTarget(this.props.sessionId, event.url, { leavingPage: false });
   }
 
-  handleNavigateFailed = (_event) => {
-    // TODO: Display an error page or something.  For now, just clear out the loading spinner.
-    this.props.setTabLoaded(this.props.sessionId, true);
+  handleNavigateFailed = ({ errorCode, errorDescription }) => {
+    this.props.setTabError(this.props.sessionId, errorCode, errorDescription);
   }
 
   handleNewWindow = (event) => {

--- a/src/browser/components/DAppContainer/DAppContainer.js
+++ b/src/browser/components/DAppContainer/DAppContainer.js
@@ -90,19 +90,17 @@ export default class DAppContainer extends React.Component {
   renderError() {
     const { target, errorCode, errorDescription } = this.props;
 
-    // Validate if there is an error code (do not check with ! as the code
-    // could have a negative value)
-    if (errorCode !== null) {
-      return (
-        <Error
-          target={target}
-          code={errorCode}
-          description={errorDescription}
-        />
-      );
+    if (errorCode === null) {
+      return null;
     }
 
-    return null;
+    return (
+      <Error
+        target={target}
+        code={errorCode}
+        description={errorDescription}
+      />
+    );
   }
 
   renderWebView() {

--- a/src/browser/components/DAppContainer/DAppContainer.scss
+++ b/src/browser/components/DAppContainer/DAppContainer.scss
@@ -5,4 +5,12 @@
   &.active {
     display: block;
   }
+
+	.webview {
+		height: 100%;
+
+	  &.hidden {
+	    display: none;
+	  }
+	}
 }

--- a/src/browser/components/DAppContainer/DAppContainer.scss
+++ b/src/browser/components/DAppContainer/DAppContainer.scss
@@ -6,11 +6,11 @@
     display: block;
   }
 
-	.webview {
-		height: 100%;
+  .webview {
+    height: 100%;
 
-	  &.hidden {
-	    display: none;
-	  }
-	}
+    &.hidden {
+      display: none;
+    }
+  }
 }

--- a/src/browser/components/DAppContainer/index.js
+++ b/src/browser/components/DAppContainer/index.js
@@ -2,10 +2,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import DAppContainer from './DAppContainer';
-import { setTabTitle, setTabTarget, setTabLoaded, closeTab } from '../../actions/browserActions';
+import { setTabError, setTabTitle, setTabTarget, setTabLoaded, closeTab } from '../../actions/browserActions';
 import { enqueue, dequeue, empty } from '../../actions/requestsActions';
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
+  setTabError,
   setTabTitle,
   setTabTarget,
   setTabLoaded,

--- a/src/browser/components/Error/Error.js
+++ b/src/browser/components/Error/Error.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { string, number } from 'prop-types';
+
+import styles from './Error.scss';
+
+export default class Error extends React.Component {
+  static propTypes = {
+    target: string.isRequired,
+    code: number.isRequired,
+    description: string.isRequired
+  }
+
+  render() {
+    return (
+      <div className={styles.error}>
+        {this.renderTitle()}
+        {this.renderDescription()}
+      </div>
+    );
+  }
+
+  renderTitle() {
+    return (
+      <h1>Error {this.props.code}</h1>
+    );
+  }
+
+  renderDescription() {
+    return (
+      <div>
+        <p>
+          <strong>{this.props.target}</strong> could not be found.
+        </p>
+        <p>{this.props.description}</p>
+      </div>
+    );
+  }
+}

--- a/src/browser/components/Error/Error.scss
+++ b/src/browser/components/Error/Error.scss
@@ -1,7 +1,7 @@
 .error {
   display: flex;
-	height: 100%;
+  height: 100%;
   flex-direction: column;
   align-items: center;
-	justify-content: center;
+  justify-content: center;
 }

--- a/src/browser/components/Error/Error.scss
+++ b/src/browser/components/Error/Error.scss
@@ -1,0 +1,7 @@
+.error {
+  display: flex;
+	height: 100%;
+  flex-direction: column;
+  align-items: center;
+	justify-content: center;
+}

--- a/src/browser/components/Error/index.js
+++ b/src/browser/components/Error/index.js
@@ -1,0 +1,5 @@
+import { connect } from 'react-redux';
+
+import Error from './Error';
+
+export default connect(null, null)(Error);

--- a/src/browser/reducers/browserReducer.js
+++ b/src/browser/reducers/browserReducer.js
@@ -1,7 +1,7 @@
 import uuid from 'uuid/v1';
 import { keys, omit, has, size } from 'lodash';
 
-import { OPEN_TAB, CLOSE_TAB, SET_ACTIVE_TAB, SET_TAB_TITLE, SET_TAB_TARGET, SET_TAB_LOADED } from '../actions/browserActions';
+import { OPEN_TAB, CLOSE_TAB, SET_ACTIVE_TAB, SET_TAB_ERROR, SET_TAB_TITLE, SET_TAB_TARGET, SET_TAB_LOADED } from '../actions/browserActions';
 import parseURL from '../util/parseURL';
 
 const initialTabState = {
@@ -9,7 +9,9 @@ const initialTabState = {
   title: 'My nOS',
   addressBarEntry: true,
   loading: false,
-  requestCount: 1
+  requestCount: 1,
+  errorCode: null,
+  errorDescription: null
 };
 
 const newTabState = {
@@ -109,6 +111,14 @@ function setTitle(state, action) {
   return updateTab(state, action.sessionId, { title: action.title });
 }
 
+function setError(state, action) {
+  return updateTab(state, action.sessionId, {
+    loading: false,
+    errorCode: action.code,
+    errorDescription: action.description
+  });
+}
+
 function setTarget(state, action) {
   const tab = state.tabs[action.sessionId];
 
@@ -123,7 +133,9 @@ function setTarget(state, action) {
     title: target,
     loading: action.leavingPage,
     addressBarEntry: action.addressBarEntry,
-    requestCount: tab.requestCount + 1
+    requestCount: tab.requestCount + 1,
+    errorCode: null,
+    errorDescription: null
   });
 }
 
@@ -139,6 +151,8 @@ export default function browserReducer(state = generateInitialState(), action) {
       return close(state, action);
     case SET_ACTIVE_TAB:
       return focus(state, action);
+    case SET_TAB_ERROR:
+      return setError(state, action);
     case SET_TAB_TITLE:
       return setTitle(state, action);
     case SET_TAB_TARGET:


### PR DESCRIPTION
## Description
This PR implements the business logic required to show any type of error when a page could not be loaded (implementation of specific errors could be done in other PR's).

Take notice of Electron's errors https://cs.chromium.org/chromium/src/net/base/net_error_list.h

## Motivation and Context
Currently when, particularly, nos:// domains couldn't be loaded it's unknown what's happening. The browsers shows an empty screen. To give the user some more insights about the error we would like to provide a custom `Error` component with more details (which target, error and description of the error).

## How Has This Been Tested?
- [x] Unhappy page loading flows (no internet, proxy, invalid url, etc.)
- [x] Switch between tabs, reloading pages and changing urls after errors
- [x] Enhanced the testsuite with an error tab (see `tab-3`)
- [x] nOS Local / localhost / dApp startkit

## Screenshots (if appropriate):
![screen shot 2018-06-12 at 23 04 50](https://user-images.githubusercontent.com/529396/41317601-fa27c3ae-6e95-11e8-936b-add9979cc9a6.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
Fixes #188