### PR TITLE
chore(register): passphrase removal

### DIFF
--- a/__tests__/register/components/AccountDetails/AccountDetails.test.js
+++ b/__tests__/register/components/AccountDetails/AccountDetails.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import AccountDetails from 'register/components/AccountDetails/AccountDetails';
+
+describe('<AccountDetails />', () => {
+  const account = {
+    address: 'my-address',
+    key: 'my-key',
+    encryptedKey: 'my-encrypted-key',
+    passphrase: 'my-passphrase'
+  };
+  let wrapper;
+
+  const findDatum = (label) => {
+    return wrapper.find('AccountDatum').findWhere((node) => node.prop('label') === label);
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<AccountDetails account={account} />);
+  });
+
+  it('renders address', () => {
+    expect(findDatum('Address').prop('value')).toEqual(account.address);
+  });
+
+  it('renders private key', () => {
+    expect(findDatum('Private Key').prop('value')).toEqual(account.key);
+  });
+
+  it('renders encrypted key', () => {
+    expect(findDatum('Encrypted Key').prop('value')).toEqual(account.encryptedKey);
+  });
+
+  it('does not render passphrase', () => {
+    expect(findDatum('Passphrase')).toHaveLength(0);
+  });
+});

--- a/src/register/components/AccountDetails/AccountDatum/AccountDatum.js
+++ b/src/register/components/AccountDetails/AccountDatum/AccountDatum.js
@@ -10,7 +10,7 @@ import styles from './AccountDatum.scss';
 
 const COPIED_DURATION = 2000;
 
-export default class AccountDetails extends React.Component {
+export default class AccountDatum extends React.Component {
   static propTypes = {
     label: string.isRequired,
     value: string.isRequired

--- a/src/register/components/AccountDetails/AccountDetails.js
+++ b/src/register/components/AccountDetails/AccountDetails.js
@@ -16,7 +16,6 @@ export default function AccountDetails(props) {
         <AccountDatum label="Address" value={account.address} />
         <AccountDatum label="Private Key" value={account.key} />
         <AccountDatum label="Encrypted Key" value={account.encryptedKey} />
-        <AccountDatum label="Passphrase" value={account.passphrase} />
       </div>
       <div className={styles.actions}>
         <Link to="/login">Login</Link>


### PR DESCRIPTION
## Description
This removed the "passphrase" from the account details screen after registering.

## Motivation and Context
Since the user enters their desired passphrase twice into two password fields, there's no reason to show the plaintext password on the next screen.

## How Has This Been Tested?
I smoke tested registering, ensured that saving a wallet still works as expected, and added a few component tests.

## Screenshots (if appropriate):
<img width="538" alt="screen shot 2018-06-13 at 10 00 04 pm" src="https://user-images.githubusercontent.com/169093/41389227-2e64335e-6f55-11e8-87e6-44f4e5f1bd99.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
N/A