### PR TITLE
feat(browser): Focusing the address bar should select/highlight the c…

### DIFF
--- a/src/browser/components/AddressBar/AddressBar.js
+++ b/src/browser/components/AddressBar/AddressBar.js
@@ -35,12 +35,17 @@ export default class AddressBar extends React.Component {
           ref={this.registerRef}
           type="text"
           placeholder="Search or enter address"
+          onFocus={this.handleFocus}
           onKeyDown={this.handleKeyDown}
           defaultValue={this.props.query}
         />
         <ButtonBar />
       </div>
     );
+  }
+
+  handleFocus = (event) => {
+    event.target.select();
   }
 
   handleKeyDown = (event) => {


### PR DESCRIPTION
## Description
This change ensures that the content of the address bar is selected when the user focuses it.

## Motivation and Context
Quick deletion or entry of a new address when clicking or tabbing into the address bar.

## How Has This Been Tested?
Smoke tested tabbing into, clicking into the address bar. Subsequent clicks allow the cursor to be positioned anywhere within the address.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
Fixes #237

