### PR TITLE
chore(error): propagate catched error as prop into withRejectMessage

### DIFF
--- a/__tests__/browser/components/RequestsProcessor/GetBalance/index.test.js
+++ b/__tests__/browser/components/RequestsProcessor/GetBalance/index.test.js
@@ -117,7 +117,7 @@ describe('<GetBalance />', () => {
 
       it('rejects', () => {
         wrapper.update();
-        expect(onReject).toHaveBeenCalledWith('Your account balance could not be retrieved.\nFake test error');
+        expect(onReject).toHaveBeenCalledWith('Your account balance could not be retrieved: Fake test error');
         expect(onResolve).not.toHaveBeenCalled();
       });
     });

--- a/__tests__/browser/components/RequestsProcessor/GetBalance/index.test.js
+++ b/__tests__/browser/components/RequestsProcessor/GetBalance/index.test.js
@@ -117,7 +117,7 @@ describe('<GetBalance />', () => {
 
       it('rejects', () => {
         wrapper.update();
-        expect(onReject).toHaveBeenCalledWith('Your account balance could not be retrieved.');
+        expect(onReject).toHaveBeenCalledWith('Your account balance could not be retrieved.\nFake test error');
         expect(onResolve).not.toHaveBeenCalled();
       });
     });

--- a/src/renderer/browser/components/RequestsProcessor/ClaimGas/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/ClaimGas/index.js
@@ -34,7 +34,7 @@ export default function makeClaimComponent(claimActions) {
       wif
     })),
     withNullLoader(claimActions),
-    withRejectMessage(claimActions, ({ error }) => (`Could not claim GAS.\n${error}`)),
+    withRejectMessage(claimActions, ({ error }) => (`Could not claim GAS: ${error}`)),
     withData(claimActions, mapSendDataToProps)
   )(ClaimGas);
 }

--- a/src/renderer/browser/components/RequestsProcessor/ClaimGas/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/ClaimGas/index.js
@@ -34,7 +34,7 @@ export default function makeClaimComponent(claimActions) {
       wif
     })),
     withNullLoader(claimActions),
-    withRejectMessage(claimActions, 'Could not claim GAS.'),
+    withRejectMessage(claimActions, ({ error }) => (`Could not claim GAS.\n${error}`)),
     withData(claimActions, mapSendDataToProps)
   )(ClaimGas);
 }

--- a/src/renderer/browser/components/RequestsProcessor/GetBalance/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetBalance/index.js
@@ -37,7 +37,7 @@ export default function makeGetBalance(balancesActions) {
     // Get the balance & wait for success or failure
     withCall(balancesActions, ({ net, address }) => ({ net, address })),
     withNullLoader(balancesActions),
-    withRejectMessage(balancesActions, 'Your account balance could not be retrieved.'),
+    withRejectMessage(balancesActions, ({ error }) => (`Your account balance could not be retrieved.\n${error}`)),
     withData(balancesActions, mapBalancesDataToProps)
   )(GetBalance);
 }

--- a/src/renderer/browser/components/RequestsProcessor/GetBalance/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetBalance/index.js
@@ -37,7 +37,7 @@ export default function makeGetBalance(balancesActions) {
     // Get the balance & wait for success or failure
     withCall(balancesActions, ({ net, address }) => ({ net, address })),
     withNullLoader(balancesActions),
-    withRejectMessage(balancesActions, ({ error }) => (`Your account balance could not be retrieved.\n${error}`)),
+    withRejectMessage(balancesActions, ({ error }) => (`Your account balance could not be retrieved: ${error}`)),
     withData(balancesActions, mapBalancesDataToProps)
   )(GetBalance);
 }

--- a/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
@@ -46,7 +46,7 @@ export default function makeStorageComponent(storageActions) {
     })),
     withNullLoader(storageActions),
     withRejectMessage(storageActions, (props) => (
-      `Retrieving storage failed for key "${props.index}" on "${props.scriptHash}"`
+      `Retrieving storage failed for key "${props.index}" on "${props.scriptHash}"\n${props.error}`
     )),
     withData(storageActions, mapStorageDataToProps)
   )(GetStorage);

--- a/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
@@ -45,8 +45,8 @@ export default function makeStorageComponent(storageActions) {
       decodeOutput
     })),
     withNullLoader(storageActions),
-    withRejectMessage(storageActions, (props) => (
-      `Retrieving storage failed for key "${props.index}" on "${props.scriptHash}"\n${props.error}`
+    withRejectMessage(storageActions, ({ index, scriptHash, error }) => (
+      `Retrieving storage failed for key "${index}" on "${scriptHash}"\n${error}`
     )),
     withData(storageActions, mapStorageDataToProps)
   )(GetStorage);

--- a/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetStorage/index.js
@@ -46,7 +46,7 @@ export default function makeStorageComponent(storageActions) {
     })),
     withNullLoader(storageActions),
     withRejectMessage(storageActions, ({ index, scriptHash, error }) => (
-      `Retrieving storage failed for key "${index}" on "${scriptHash}"\n${error}`
+      `Retrieving storage failed for key "${index}" on "${scriptHash}": ${error}`
     )),
     withData(storageActions, mapStorageDataToProps)
   )(GetStorage);

--- a/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
@@ -53,7 +53,7 @@ export default function makeInvokeComponent(invokeActions) {
     })),
     withNullLoader(invokeActions),
     withRejectMessage(invokeActions, ({ operation, scriptHash, error }) => (
-      `Could not perform operation '${operation}' on contract with address '${scriptHash}'\n${error}`
+      `Could not perform operation '${operation}' on contract with address '${scriptHash}': ${error}`
     )),
     withData(invokeActions, mapInvokeDataToProps)
   )(Invoke);

--- a/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
@@ -52,8 +52,8 @@ export default function makeInvokeComponent(invokeActions) {
       encodeArgs
     })),
     withNullLoader(invokeActions),
-    withRejectMessage(invokeActions, ({ operation, scriptHash }) => (
-      `Could not perform operation '${operation}' on contract with address '${scriptHash}'`
+    withRejectMessage(invokeActions, ({ operation, scriptHash, error }) => (
+      `Could not perform operation '${operation}' on contract with address '${scriptHash}'\n${error}`
     )),
     withData(invokeActions, mapInvokeDataToProps)
   )(Invoke);

--- a/src/renderer/browser/components/RequestsProcessor/Send/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Send/index.js
@@ -55,8 +55,8 @@ export default function makeSendComponent(sendActions) {
       wif
     })),
     withNullLoader(sendActions),
-    withRejectMessage(sendActions, ({ amount, asset, receiver }) => (
-      `Could not send ${amount} ${asset} to ${receiver}`
+    withRejectMessage(sendActions, ({ amount, asset, receiver, error }) => (
+      `Could not send ${amount} ${asset} to ${receiver}\n${error}`
     )),
     withData(sendActions, mapSendDataToProps)
   )(Send);

--- a/src/renderer/browser/components/RequestsProcessor/Send/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Send/index.js
@@ -56,7 +56,7 @@ export default function makeSendComponent(sendActions) {
     })),
     withNullLoader(sendActions),
     withRejectMessage(sendActions, ({ amount, asset, receiver, error }) => (
-      `Could not send ${amount} ${asset} to ${receiver}\n${error}`
+      `Could not send ${amount} ${asset} to ${receiver}: ${error}`
     )),
     withData(sendActions, mapSendDataToProps)
   )(Send);

--- a/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
@@ -40,7 +40,7 @@ export default function makeStorageComponent(testInvokeActions) {
     })),
     withNullLoader(testInvokeActions),
     withRejectMessage(testInvokeActions, (props) => (
-      `Invocation failed for operation "${props.operation}" on "${props.scriptHash}"`
+      `Invocation failed for operation "${props.operation}" on "${props.scriptHash}"\n${props.error}`
     )),
     withData(testInvokeActions, mapInvokeDataToProps)
   )(TestInvoke);

--- a/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
@@ -40,7 +40,7 @@ export default function makeStorageComponent(testInvokeActions) {
     })),
     withNullLoader(testInvokeActions),
     withRejectMessage(testInvokeActions, ({ operation, scriptHash, error }) => (
-      `Invocation failed for operation "${operation}" on "${scriptHash}"\n${error}`
+      `Invocation failed for operation "${operation}" on "${scriptHash}": ${error}`
     )),
     withData(testInvokeActions, mapInvokeDataToProps)
   )(TestInvoke);

--- a/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/TestInvoke/index.js
@@ -39,8 +39,8 @@ export default function makeStorageComponent(testInvokeActions) {
       encodeArgs
     })),
     withNullLoader(testInvokeActions),
-    withRejectMessage(testInvokeActions, (props) => (
-      `Invocation failed for operation "${props.operation}" on "${props.scriptHash}"\n${props.error}`
+    withRejectMessage(testInvokeActions, ({ operation, scriptHash, error }) => (
+      `Invocation failed for operation "${operation}" on "${scriptHash}"\n${error}`
     )),
     withData(testInvokeActions, mapInvokeDataToProps)
   )(TestInvoke);

--- a/src/renderer/browser/hocs/withRejectMessage.js
+++ b/src/renderer/browser/hocs/withRejectMessage.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { func } from 'prop-types';
 import { isFunction } from 'lodash';
-import { withProgressComponents, progressValues } from 'spunky';
+import { withProgressComponents, withError, progressValues } from 'spunky';
+import { compose } from 'recompose';
 
 const { FAILED } = progressValues;
+
+const mapErrorToProps = (error) => ({ error });
 
 export default function withRejectMessage(actions, message, options = {}) {
   class RejectMessageComponent extends React.Component {
@@ -20,7 +23,10 @@ export default function withRejectMessage(actions, message, options = {}) {
     }
   }
 
-  return withProgressComponents(actions, {
-    [FAILED]: RejectMessageComponent
-  }, options);
+  return compose(
+    withError(actions, mapErrorToProps),
+    withProgressComponents(actions, {
+      [FAILED]: RejectMessageComponent
+    }, options)
+  );
 }


### PR DESCRIPTION
## Description
When using `withRejectMessage` HOC `error` prop will be made available if `Error` was thrown

## Motivation and Context
#108

## How Has This Been Tested?
Tested in dApp template + updated test for `GetBalance`

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have read the **CONTRIBUTING** document.

## Closing issues
closes #108
