### PR TITLE
chore(main): fixed rendering wrong window

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,7 +46,7 @@ let splashWindow;
 
 const isMac = process.platform === 'darwin';
 
-function getWindowPath(productionPath, suffix = "") {
+function getWindowPath(productionPath, suffix = '') {
   return isDev
     ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/${suffix}`
     : url.format({ pathname: productionPath, protocol: 'file:', slashes: true });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,10 +46,10 @@ let splashWindow;
 
 const isMac = process.platform === 'darwin';
 
-function getWindowPath(productionPath, suffix = '') {
+function getWindowPath(productionPath, filename) {
   return isDev
-    ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/${suffix}`
-    : url.format({ pathname: productionPath, protocol: 'file:', slashes: true });
+    ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/${filename}`
+    : url.format({ pathname: path.join(productionPath, filename), protocol: 'file:', slashes: true });
 }
 
 function createWindow() {
@@ -78,8 +78,8 @@ function createWindow() {
     icon: iconPath
   });
 
-  splashWindow.loadURL(getWindowPath(path.join(getStaticPath(), 'splash.html'), 'splash.html'));
-  mainWindow.loadURL(getWindowPath(path.join(__dirname, 'index.html')));
+  splashWindow.loadURL(getWindowPath(getStaticPath(), 'splash.html'));
+  mainWindow.loadURL(getWindowPath(__dirname, 'index.html'));
 
   // When mainWindow finishes loading, then show
   // the mainWindow and destroy the splashWindow.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,9 +46,9 @@ let splashWindow;
 
 const isMac = process.platform === 'darwin';
 
-function getWindowPath(productionPath) {
+function getWindowPath(productionPath, suffix = "") {
   return isDev
-    ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/splash.html`
+    ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/${suffix}`
     : url.format({ pathname: productionPath, protocol: 'file:', slashes: true });
 }
 
@@ -78,7 +78,7 @@ function createWindow() {
     icon: iconPath
   });
 
-  splashWindow.loadURL(getWindowPath(path.join(getStaticPath(), 'splash.html')));
+  splashWindow.loadURL(getWindowPath(path.join(getStaticPath(), 'splash.html'), 'splash.html'));
   mainWindow.loadURL(getWindowPath(path.join(__dirname, 'index.html')));
 
   // When mainWindow finishes loading, then show


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

<!--- Describe your changes in detail -->
## Description
This is a little urgent - due to the eslint PR, we introduced a bug, where the main window shows the splash screen, making the app not usable


<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
## Motivation and Context
read desc


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment -->
## How Has This Been Tested?
👁 


## Screenshots (if appropriate):



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
## Checklist:
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
## Closing issues
Fixes #
