### PR TITLE
chore(balances): fix token list across networks

### DIFF
--- a/src/renderer/shared/util/getBalances.js
+++ b/src/renderer/shared/util/getBalances.js
@@ -51,7 +51,7 @@ async function getAssetBalances(net, address) {
 }
 
 export default async function getBalances({ net, address }) {
-  const endpoint = await api.loadBalance(api.getRPCEndpointFrom, { net });
+  const endpoint = await api.getRPCEndpointFrom({ net }, api.neoscan);
 
   if (!wallet.isAddress(address)) {
     throw new Error(`Invalid script hash: "${address}"`);

--- a/src/renderer/shared/util/getBalances.js
+++ b/src/renderer/shared/util/getBalances.js
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { values, sortBy, extend } from 'lodash';
+import { values, sortBy, compact, extend } from 'lodash';
 import { api, wallet } from '@cityofzion/neon-js';
 
 import { GAS, NEO } from '../values/assets';
@@ -12,10 +12,13 @@ const NETWORK_MAP = {
 
 async function getTokens(net) {
   const networkKey = NETWORK_MAP[net];
+
   const response = await fetch(TOKENS_URL);
   const tokens = values(await response.json());
+  const sortedTokens = sortBy(tokens, 'symbol');
+  const networkTokens = compact(sortedTokens.map((token) => token.networks[networkKey]));
 
-  return sortBy(tokens, 'symbol').map((token) => token.networks[networkKey].hash);
+  return networkTokens.map((token) => token.hash);
 }
 
 async function getTokenBalance(endpoint, scriptHash, address) {


### PR DESCRIPTION
## Description
Fixed token fetch across non-MainNet networks.

## Motivation and Context
Token balances were fetching correctly for MainNet, but causing an error for other networks.  Although no tokens are being listed for other networks (due to not being listed in the [neo-tokens](https://github.com/CityOfZion/neo-tokens) repo), it's not resulting in a JS error.

## How Has This Been Tested?
Pulled up the "account" page on MainNet & TestNet.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Closing issues
N/A