### PR TITLE
chore(test): fixed missing prop warning

### DIFF
--- a/__tests__/renderer/browser/components/RequestsProcessor/GetBalance/GetBalance.test.js
+++ b/__tests__/renderer/browser/components/RequestsProcessor/GetBalance/GetBalance.test.js
@@ -9,8 +9,8 @@ describe('<GetBalance />', () => {
   const defaultProps = {
     asset: NEO,
     balances: {
-      [NEO]: { scriptHash: NEO, balance: '12', decimals: 0 },
-      [GAS]: { scriptHash: GAS, balance: '1.00000007', decimals: 8 }
+      [NEO]: { scriptHash: NEO, name: 'NEO', symbol: 'NEO', balance: '12', decimals: 0 },
+      [GAS]: { scriptHash: GAS, name: 'GAS', symbol: 'GAS', balance: '1.00000007', decimals: 8 }
     },
     onResolve: noop,
     onReject: noop


### PR DESCRIPTION
## Description
This fixes a react prop warning when running tests.

## Motivation and Context
The `balanceShape` recently changed, but one of the tests that passes a prop for this shape was not 
updated.  This resulted in an annoying warning being logged to the console.

## How Has This Been Tested?
`yarn test`

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Closing issues
N/A