### PR TITLE
chore(package): add webpack-dev-server to greenkeeper ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,8 +117,9 @@
   },
   "greenkeeper": {
     "ignore": [
+      "redux",
       "webpack",
-      "redux"
+      "webpack-dev-server"
     ]
   },
   "jest": {


### PR DESCRIPTION
## Description
Adds `webpack-dev-server` to greenkeeper ignore.

## Motivation and Context
We have this package locked at a specific version that works with webpack 3.  We haven't upgraded to webpack 4 due to a number of issues outlined in other tracked github issues.

## How Has This Been Tested?
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Closing issues
N/A