### PR TITLE
chore(browser): disabled styling for navigation buttons

### DIFF
--- a/src/renderer/browser/components/AddressBar/AddressBar.scss
+++ b/src/renderer/browser/components/AddressBar/AddressBar.scss
@@ -31,17 +31,17 @@
       margin: 0.5rem;
       border: 0;
       background: transparent;
-      color: #9a99a5;
+      color: lighten(#9a99a5, 20%);
       font-size: 1rem;
 
-      &:focus,
-      &:hover {
-        color: lighten(#9a99a5, 20%);
-      }
-
-      &:active {
-        color: darken(#9a99a5, 20%);
-      }
+      // &:focus,
+      // &:hover {
+      //   color: lighten(#9a99a5, 20%);
+      // }
+      //
+      // &:active {
+      //   color: darken(#9a99a5, 20%);
+      // }
     }
   }
 }


### PR DESCRIPTION
## Description
This changes the styles of the navigation buttons so that they appear disabled.

## Motivation and Context
The back, forward, reload, and notifications buttons don't do anything right now.  By making them respond to mouse events, it could confuse the user and have them wondering why the buttons aren't responding.

## How Has This Been Tested?
Hovered the mouse over the buttons.  (See screenshot.)

## Screenshots (if appropriate):
![screen shot 2018-07-04 at 6 35 28 pm](https://user-images.githubusercontent.com/169093/42296270-6ab52722-7fb9-11e8-81b4-0e62a551c2fd.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Closing issues
N/A