### PR TITLE
feat(remark): add remark to transactions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -195,6 +195,7 @@ address on behalf of the currently authenticated account.  It requires the user 
 * `config.asset` **string** - The asset ID script hash.
 * `config.amount` **string** - The amount of the asset to send. **NOTE: It is recommended that strings are used instead of numbers to prevent floating point rounding issues.**
 * `config.receiver` **string** - The recipient address of the asset.
+* `config.remark` **string** | **string[]** (Optional) - A remark to add to transaction. **NOTE: It's either string or an array of hex strings.**
 
 #### Returns
 **string** - The contract transaction ID.

--- a/src/renderer/browser/actions/makeSendActions.js
+++ b/src/renderer/browser/actions/makeSendActions.js
@@ -9,7 +9,7 @@ export const ID = 'send';
 export default function makeSendActions(sessionId, requestId) {
   const id = generateDAppActionId(sessionId, `${ID}-${requestId}`);
 
-  return createActions(id, ({ net, asset, amount, receiver, address, wif }) => () => {
-    return sendAsset({ net, asset, amount, receiver, address, wif });
+  return createActions(id, ({ net, asset, amount, receiver, address, wif, remark }) => () => {
+    return sendAsset({ net, asset, amount, receiver, address, wif, remark });
   });
 }

--- a/src/renderer/browser/components/RequestsProcessor/Send/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Send/index.js
@@ -27,7 +27,7 @@ const getAssetName = (assetId) => {
   }
 };
 
-const CONFIG_KEYS = ['asset', 'amount', 'receiver'];
+const CONFIG_KEYS = ['asset', 'amount', 'receiver', 'remark'];
 
 export default function makeSend(sendActions) {
   return compose(
@@ -47,13 +47,14 @@ export default function makeSend(sendActions) {
     withData(authActions, mapAuthDataToProps),
 
     // Send assets & wait for success or failure
-    withInitialCall(sendActions, ({ net, amount, asset, receiver, address, wif }) => ({
+    withInitialCall(sendActions, ({ net, amount, asset, receiver, address, wif, remark }) => ({
       net,
       amount,
       asset,
       receiver,
       address,
-      wif
+      wif,
+      remark
     })),
     withNullLoader(sendActions),
     withRejectMessage(sendActions, ({ amount, asset, receiver, error }) => (


### PR DESCRIPTION
## Description
Add ability to specify remark when sending transaction.

## Motivation and Context
I think it would be useful in general to have this ability. Specifically, this is a feature needed for my dApp.

## How Has This Been Tested?
Sent transactions with/without remark specified.

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [X] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)