### PR TITLE
feat(tabs): reset on logout

### DIFF
--- a/__tests__/renderer/browser/actions/browserActions.test.js
+++ b/__tests__/renderer/browser/actions/browserActions.test.js
@@ -1,0 +1,122 @@
+import {
+  openTab,
+  closeTab,
+  resetTabs,
+  setActiveTab,
+  setTabError,
+  setTabTarget,
+  setTabTitle,
+  setTabLoaded,
+  OPEN_TAB,
+  CLOSE_TAB,
+  RESET_TABS,
+  SET_ACTIVE_TAB,
+  SET_TAB_ERROR,
+  SET_TAB_TARGET,
+  SET_TAB_TITLE,
+  SET_TAB_LOADED
+} from 'browser/actions/browserActions';
+
+describe('browserActions', () => {
+  describe('openTab', () => {
+    it('returns action object', () => {
+      const type = 'foo';
+      const target = 'bar';
+
+      expect(openTab({ type, target })).toEqual({
+        type: OPEN_TAB,
+        payload: { type, target }
+      });
+    });
+  });
+
+  describe('closeTab', () => {
+    it('returns action object', () => {
+      const sessionId = 'abc123';
+
+      expect(closeTab(sessionId)).toEqual({
+        type: CLOSE_TAB,
+        payload: { sessionId }
+      });
+    });
+  });
+
+  describe('resetTabs', () => {
+    it('returns action object', () => {
+      expect(resetTabs()).toEqual({ type: RESET_TABS });
+    });
+  });
+
+  describe('setActiveTab', () => {
+    it('returns action object', () => {
+      const sessionId = 'abc123';
+
+      expect(setActiveTab(sessionId)).toEqual({
+        type: SET_ACTIVE_TAB,
+        payload: { sessionId }
+      });
+    });
+  });
+
+  describe('setTabError', () => {
+    it('returns action object', () => {
+      const sessionId = 'abc123';
+      const code = '-1';
+      const description = 'Uh oh...';
+
+      expect(setTabError(sessionId, code, description)).toEqual({
+        type: SET_TAB_ERROR,
+        payload: { sessionId, code, description }
+      });
+    });
+  });
+
+  describe('setTabTarget', () => {
+    const sessionId = 'abc123';
+    const target = 'nos://nos.neo';
+
+    describe('without options', () => {
+      it('returns action object', () => {
+        expect(setTabTarget(sessionId, target)).toEqual({
+          type: SET_TAB_TARGET,
+          payload: { sessionId, target, addressBarEntry: false }
+        });
+      });
+    });
+
+    describe('with options', () => {
+      it('returns action object', () => {
+        const addressBarEntry = true;
+
+        expect(setTabTarget(sessionId, target, { addressBarEntry })).toEqual({
+          type: SET_TAB_TARGET,
+          payload: { sessionId, target, addressBarEntry }
+        });
+      });
+    });
+  });
+
+  describe('setTabTitle', () => {
+    it('returns action object', () => {
+      const sessionId = 'abc123';
+      const title = 'Google';
+
+      expect(setTabTitle(sessionId, title)).toEqual({
+        type: SET_TAB_TITLE,
+        payload: { sessionId, title }
+      });
+    });
+  });
+
+  describe('setTabLoaded', () => {
+    it('returns action object', () => {
+      const sessionId = 'abc123';
+      const loaded = true;
+
+      expect(setTabLoaded(sessionId, loaded)).toEqual({
+        type: SET_TAB_LOADED,
+        payload: { sessionId, loaded }
+      });
+    });
+  });
+});

--- a/__tests__/renderer/browser/reducers/browserReducer.test.js
+++ b/__tests__/renderer/browser/reducers/browserReducer.test.js
@@ -1,0 +1,48 @@
+import { keys } from 'lodash';
+
+import browserReducer from 'browser/reducers/browserReducer';
+import { EXTERNAL } from 'browser/values/browserValues';
+import {
+  OPEN_TAB,
+  // CLOSE_TAB,
+  RESET_TABS
+  // SET_ACTIVE_TAB,
+  // SET_TAB_ERROR,
+  // SET_TAB_TARGET,
+  // SET_TAB_TITLE,
+  // SET_TAB_LOADED
+} from 'browser/actions/browserActions';
+
+describe('browserReducer', () => {
+  const initialState = browserReducer();
+
+  it('returns initial state', () => {
+    expect(initialState.activeSessionId).toMatch(/[-a-f0-9]+/);
+    expect(keys(initialState.tabs)).toEqual([initialState.activeSessionId]);
+  });
+
+  describe('action type OPEN_TAB', () => {
+    const state = browserReducer(initialState, {
+      type: OPEN_TAB,
+      payload: { type: EXTERNAL, target: 'nos://example.neo' }
+    });
+
+    expect(state.activeSessionId).not.toEqual(initialState.activeSessionId);
+    expect(keys(state.tabs)).toEqual([initialState.activeSessionId, state.activeSessionId]);
+  });
+
+  describe('action type RESET_TABS', () => {
+    const intermediateState = browserReducer(initialState, {
+      type: OPEN_TAB,
+      payload: { type: EXTERNAL, target: 'nos://example.neo' }
+    });
+
+    const state = browserReducer(intermediateState, {
+      type: RESET_TABS
+    });
+
+    expect(keys(state.tabs)).toHaveLength(1);
+    expect(state.activeSessionId).not.toEqual(initialState.activeSessionId);
+    expect(state.activeSessionId).not.toEqual(intermediateState.activeSessionId);
+  });
+});

--- a/src/renderer/browser/actions/browserActions.js
+++ b/src/renderer/browser/actions/browserActions.js
@@ -2,6 +2,7 @@ import { EXTERNAL } from '../values/browserValues';
 
 export const OPEN_TAB = 'OPEN_TAB';
 export const CLOSE_TAB = 'CLOSE_TAB';
+export const RESET_TABS = 'RESET_TABS';
 export const SET_ACTIVE_TAB = 'SET_ACTIVE_TAB';
 export const SET_TAB_ERROR = 'SET_TAB_ERROR';
 export const SET_TAB_TARGET = 'SET_TAB_TARGET';
@@ -18,6 +19,10 @@ export const openTab = ({ type = EXTERNAL, target = DEFAULT_TARGET } = {}) => ({
 export const closeTab = (sessionId) => ({
   type: CLOSE_TAB,
   payload: { sessionId }
+});
+
+export const resetTabs = () => ({
+  type: RESET_TABS
 });
 
 export const setActiveTab = (sessionId) => ({

--- a/src/renderer/browser/reducers/browserReducer.js
+++ b/src/renderer/browser/reducers/browserReducer.js
@@ -6,6 +6,7 @@ import { INTERNAL, EXTERNAL } from '../values/browserValues';
 import {
   OPEN_TAB,
   CLOSE_TAB,
+  RESET_TABS,
   SET_ACTIVE_TAB,
   SET_TAB_ERROR,
   SET_TAB_TITLE,
@@ -168,12 +169,14 @@ function setLoaded(state, action) {
   return updateTab(state, action.sessionId, { loading: !action.loaded });
 }
 
-export default function browserReducer(state = generateInitialState(), action) {
+export default function browserReducer(state = generateInitialState(), action = {}) {
   switch (action.type) {
     case OPEN_TAB:
       return open(state, action.payload);
     case CLOSE_TAB:
       return close(state, action.payload);
+    case RESET_TABS:
+      return generateInitialState();
     case SET_ACTIVE_TAB:
       return focus(state, action.payload);
     case SET_TAB_ERROR:

--- a/src/renderer/logout/components/Logout/index.js
+++ b/src/renderer/logout/components/Logout/index.js
@@ -3,16 +3,18 @@ import { withActions } from 'spunky';
 import { connect } from 'react-redux';
 
 import accountActions from 'shared/actions/accountActions';
+import { resetTabs } from 'browser/actions/browserActions';
 import { emptyAll } from 'browser/actions/requestsActions';
 
 import Logout from './Logout';
 import withLogout from '../../hocs/withLogout';
 
 const mapActionsToProps = ({ reset }) => ({
-  reset
+  resetAuth: reset
 });
 
 const mapDispatchToProps = (dispatch) => ({
+  resetAllTabs: () => dispatch(resetTabs()),
   emptyAllRequests: () => dispatch(emptyAll())
 });
 
@@ -20,9 +22,10 @@ export default compose(
   connect(null, mapDispatchToProps),
   withActions(accountActions, mapActionsToProps),
   withLogout((state, { history }) => history.push('/login')),
-  withProps(({ emptyAllRequests, reset }) => ({
+  withProps(({ emptyAllRequests, resetAllTabs, resetAuth }) => ({
     logout: () => {
-      reset();
+      resetAuth();
+      resetAllTabs();
       emptyAllRequests();
     }
   }))


### PR DESCRIPTION
## Description
This ensures that the browser tabs are reset between authenticated sessions.

## Motivation and Context
We want to work towards securing what users see within their own sessions.

## How Has This Been Tested?
1. Sign into an account.
2. Open two or more tabs.
3. Sign out & in again.
4. Observe tabs reset.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #343