### PR TITLE
chore(browser): prevent page errors for sub-resources

### DIFF
--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -145,8 +145,10 @@ export default class DAppContainer extends React.Component {
     this.props.setTabTarget(this.props.sessionId, event.url);
   }
 
-  handleNavigateFailed = ({ errorCode, errorDescription }) => {
-    this.props.setTabError(this.props.sessionId, errorCode, errorDescription);
+  handleNavigateFailed = ({ errorCode, errorDescription, isMainFrame }) => {
+    if (isMainFrame) {
+      this.props.setTabError(this.props.sessionId, errorCode, errorDescription);
+    }
   }
 
   handleNewWindow = (event) => {


### PR DESCRIPTION
## Description
Fixes issue where a full screen error message was displaying for sub-resources (images, scripts, stylesheets, etc.) failing to load.

## Motivation and Context
We only want to show an error message when the address bar's URI fails to loads.  Dependencies failing to load should not cause an issue.

## How Has This Been Tested?
1. Load https://bitsofco.de/styling-broken-images/ in nOS to ensure it loads without an error screen.
2. Load nos://fake.neo to ensure it shows an error screen.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #353