### PR TITLE
chore(button): cleanup

### DIFF
--- a/src/renderer/account/components/SendPanel/SendPanel.js
+++ b/src/renderer/account/components/SendPanel/SendPanel.js
@@ -79,6 +79,7 @@ export default class SendPanel extends React.Component {
             onChange={this.handleChangeRecipient}
           />
           <Button
+            className={styles.next}
             type="submit"
             disabled={loading || !this.isValid()}
             onClick={this.handleTransfer}

--- a/src/renderer/account/components/SendPanel/SendPanel.scss
+++ b/src/renderer/account/components/SendPanel/SendPanel.scss
@@ -12,12 +12,9 @@
     font-weight: 500;
   }
 
-  .actions {
-    margin-top: 8px;
-
-    .icon {
-      margin-right: 6px;
-    }
+  .next {
+    display: block;
+    width: 100%;
   }
 
   input[type=number]::-webkit-inner-spin-button,

--- a/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.scss
+++ b/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.scss
@@ -2,14 +2,9 @@
   .actions {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
     margin-top: 24px;
     padding-top: 16px;
     border-top: 1px solid rgba(#000, 0.1);
-
-    .login {
-      flex: 0 0 1%;
-    }
 
     .register {
       flex: 0 0 auto;

--- a/src/renderer/register/components/RegisterForm/RegisterForm.scss
+++ b/src/renderer/register/components/RegisterForm/RegisterForm.scss
@@ -2,14 +2,9 @@
   .actions {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
     margin-top: 24px;
     padding-top: 16px;
     border-top: 1px solid rgba(#000, 0.1);
-
-    .register {
-      flex: 0 0 1%;
-    }
 
     .login {
       flex: 0 0 auto;

--- a/src/renderer/shared/components/Forms/Button/Button.scss
+++ b/src/renderer/shared/components/Forms/Button/Button.scss
@@ -13,6 +13,7 @@
   box-shadow: 0 2px 10px rgba(#353445, 0.15),
               0 3px 6px rgba(#8bc83c, 0.3);
   cursor: pointer;
+  -webkit-font-smoothing: antialiased;
 
   &:focus {
     // box-shadow: 0 0 0 0.2rem rgba(#047bf8, 0.5);

--- a/src/renderer/shared/components/Forms/Button/Button.scss
+++ b/src/renderer/shared/components/Forms/Button/Button.scss
@@ -20,5 +20,6 @@
 
   &[disabled] {
     // opacity: 0.8;
+    cursor: not-allowed;
   }
 }

--- a/src/renderer/shared/components/Forms/Button/Button.scss
+++ b/src/renderer/shared/components/Forms/Button/Button.scss
@@ -1,6 +1,5 @@
 .button {
-  display: block;
-  width: 100%;
+  display: inline-block;
   height: 36px;
   padding: 0 24px;
   background: linear-gradient(90deg, #b9d532 0%, #5bba47 100%);

--- a/src/renderer/shared/components/Forms/Input/Input.scss
+++ b/src/renderer/shared/components/Forms/Input/Input.scss
@@ -23,6 +23,7 @@
     line-height: 17px;
     font-size: 14px;
     font-weight: 500;
+    -webkit-font-smoothing: antialiased;
 
     &::placeholder {
       color: $light-text-color;

--- a/src/renderer/shared/components/Forms/Select/Select.scss
+++ b/src/renderer/shared/components/Forms/Select/Select.scss
@@ -23,6 +23,7 @@
     line-height: 17px;
     font-size: 14px;
     font-weight: 500;
+    -webkit-font-smoothing: antialiased;
 
     &::placeholder {
       color: $light-text-color;


### PR DESCRIPTION
## Description
This cleans up the new button styles in a few ways:

* antialiases the labels to better match designs
* makes them `inline-block` instead of `block` by default
* adds a `not-allowed` cursor for disabled buttons

## Motivation and Context
Some of the styles and behavior didn't look right compared to designs.

## How Has This Been Tested?
Opening the screens that have buttons and ensuring they match expectations.

## Screenshots (if appropriate)
![screen shot 2018-07-25 at 10 37 09 pm](https://user-images.githubusercontent.com/169093/43240282-4ce1917e-905b-11e8-9a1c-cd4de25989ed.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A