### PR TITLE
Minor rendering performance improvements

### DIFF
--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
@@ -16,7 +16,7 @@ function reduceOthers(data) {
   return reduce(data, (sum, datum) => sum + datum.value, 0);
 }
 
-export default class Breakdown extends React.Component {
+export default class Breakdown extends React.PureComponent {
   static propTypes = {
     className: string,
     data: chartDataShape.isRequired,

--- a/src/renderer/account/components/AccountPanel/Holdings/Holdings.js
+++ b/src/renderer/account/components/AccountPanel/Holdings/Holdings.js
@@ -6,7 +6,7 @@ import TokenBalance from '../TokenBalance';
 import balanceShape from '../../../shapes/balanceShape';
 import styles from './Holdings.scss';
 
-export default class Holdings extends React.Component {
+export default class Holdings extends React.PureComponent {
   static propTypes = {
     className: string,
     balances: arrayOf(balanceShape).isRequired,

--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
@@ -10,7 +10,7 @@ import balanceShape from '../../../shapes/balanceShape';
 import formatCurrency from '../../../util/formatCurrency';
 import styles from './TokenBalance.scss';
 
-export default class TokenBalance extends React.Component {
+export default class TokenBalance extends React.PureComponent {
   static propTypes = {
     className: string,
     token: balanceShape.isRequired,

--- a/src/renderer/account/components/SendPanel/SendPanel.js
+++ b/src/renderer/account/components/SendPanel/SendPanel.js
@@ -14,7 +14,7 @@ import styles from './SendPanel.scss';
 import isNumeric from '../../util/isNumeric';
 import balanceShape from '../../shapes/balanceShape';
 
-export default class SendPanel extends React.Component {
+export default class SendPanel extends React.PureComponent {
   static propTypes = {
     className: string,
     loading: bool.isRequired,

--- a/src/renderer/browser/components/Browser/Browser.js
+++ b/src/renderer/browser/components/Browser/Browser.js
@@ -10,7 +10,7 @@ import DAppContainer from '../DAppContainer';
 import tabShape from '../../shapes/tabShape';
 import styles from './Browser.scss';
 
-export default class Browser extends React.Component {
+export default class Browser extends React.PureComponent {
   static propTypes = {
     activeSessionId: string.isRequired,
     tabs: objectOf(tabShape).isRequired

--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -10,7 +10,7 @@ import RequestsProcessor from '../RequestsProcessor';
 import tabShape from '../../shapes/tabShape';
 import styles from './DAppContainer.scss';
 
-export default class DAppContainer extends React.Component {
+export default class DAppContainer extends React.PureComponent {
   static propTypes = {
     className: string,
     sessionId: string.isRequired,

--- a/src/renderer/browser/components/Error/Error.js
+++ b/src/renderer/browser/components/Error/Error.js
@@ -3,7 +3,7 @@ import { string, number } from 'prop-types';
 
 import styles from './Error.scss';
 
-export default class Error extends React.Component {
+export default class Error extends React.PureComponent {
   static propTypes = {
     target: string.isRequired,
     code: number.isRequired,

--- a/src/renderer/browser/components/InternalPage/InternalPage.js
+++ b/src/renderer/browser/components/InternalPage/InternalPage.js
@@ -4,7 +4,7 @@ import { string } from 'prop-types';
 import tabShape from 'browser/shapes/tabShape';
 import getInternalPageComponent from 'shared/util/getInternalPageComponent';
 
-export default class InternalPage extends React.Component {
+export default class InternalPage extends React.PureComponent {
   static propTypes = {
     className: string,
     tab: tabShape.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/ClaimGas/ClaimGas.js
+++ b/src/renderer/browser/components/RequestsProcessor/ClaimGas/ClaimGas.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { string, func } from 'prop-types';
 
-export default class ClaimGas extends React.Component {
+export default class ClaimGas extends React.PureComponent {
   static propTypes = {
     txid: string.isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/GetAddress/GetAddress.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetAddress/GetAddress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { string, func } from 'prop-types';
 
-export default class GetAddress extends React.Component {
+export default class GetAddress extends React.PureComponent {
   static propTypes = {
     address: string.isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/GetBalance/GetBalance.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetBalance/GetBalance.js
@@ -9,7 +9,7 @@ function isValidAssetHash(asset) {
   return wallet.isScriptHash(asset) || [NEO, GAS].includes(asset);
 }
 
-export default class GetBalance extends React.Component {
+export default class GetBalance extends React.PureComponent {
   static propTypes = {
     balances: objectOf(balanceShape).isRequired,
     asset: string.isRequired,

--- a/src/renderer/browser/components/RequestsProcessor/GetStorage/GetStorage.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetStorage/GetStorage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { func, any, objectOf } from 'prop-types';
 
-export default class GetStorage extends React.Component {
+export default class GetStorage extends React.PureComponent {
   static propTypes = {
     data: objectOf(any).isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/Invoke/Invoke.js
+++ b/src/renderer/browser/components/RequestsProcessor/Invoke/Invoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { string, func } from 'prop-types';
 
-export default class Invoke extends React.Component {
+export default class Invoke extends React.PureComponent {
   static propTypes = {
     txid: string.isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/RequestProcessor.js
+++ b/src/renderer/browser/components/RequestsProcessor/RequestProcessor.js
@@ -5,7 +5,7 @@ import { isEqual } from 'lodash';
 import { getComponent, getActions } from './mappings';
 import requestShape from '../../shapes/requestShape';
 
-export default class RequestProcessor extends React.Component {
+export default class RequestProcessor extends React.PureComponent {
   static propTypes = {
     sessionId: string.isRequired,
     src: string.isRequired,

--- a/src/renderer/browser/components/RequestsProcessor/RequestsProcessor.js
+++ b/src/renderer/browser/components/RequestsProcessor/RequestsProcessor.js
@@ -5,7 +5,7 @@ import { omit } from 'lodash';
 import RequestProcessor from './RequestProcessor';
 import requestShape from '../../shapes/requestShape';
 
-export default class RequestsProcessor extends React.Component {
+export default class RequestsProcessor extends React.PureComponent {
   static propTypes = {
     sessionId: string.isRequired,
     src: string.isRequired,

--- a/src/renderer/browser/components/RequestsProcessor/Send/Send.js
+++ b/src/renderer/browser/components/RequestsProcessor/Send/Send.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { string, func } from 'prop-types';
 
-export default class Send extends React.Component {
+export default class Send extends React.PureComponent {
   static propTypes = {
     txid: string.isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
+++ b/src/renderer/browser/components/RequestsProcessor/TestInvoke/TestInvoke.js
@@ -3,7 +3,7 @@ import { func } from 'prop-types';
 
 import testInvokeShape from '../../../shapes/testInvokeShape';
 
-export default class TestInvoke extends React.Component {
+export default class TestInvoke extends React.PureComponent {
   static propTypes = {
     result: testInvokeShape.isRequired,
     onResolve: func.isRequired

--- a/src/renderer/browser/hocs/withClean.js
+++ b/src/renderer/browser/hocs/withClean.js
@@ -10,7 +10,7 @@ export default function withClean(actions, { propName = ACTION_PROP } = {}) {
   });
 
   return (Component) => {
-    class WithCleanComponent extends React.Component {
+    class WithCleanComponent extends React.PureComponent {
       componentWillUnmount() {
         this.props[propName]();
       }

--- a/src/renderer/browser/hocs/withPrompt/index.js
+++ b/src/renderer/browser/hocs/withPrompt/index.js
@@ -8,7 +8,7 @@ import styles from './styles.scss';
 
 export default function withPrompt(message) {
   return (Component) => {
-    class PromptComponent extends React.Component {
+    class PromptComponent extends React.PureComponent {
       static propTypes = {
         confirm: func.isRequired,
         src: string.isRequired,

--- a/src/renderer/browser/hocs/withRejectMessage.js
+++ b/src/renderer/browser/hocs/withRejectMessage.js
@@ -9,7 +9,7 @@ const { FAILED } = progressValues;
 const mapErrorToProps = (error) => ({ error });
 
 export default function withRejectMessage(actions, message, options = {}) {
-  class RejectMessageComponent extends React.Component {
+  class RejectMessageComponent extends React.PureComponent {
     static propTypes = {
       onReject: func.isRequired
     };

--- a/src/renderer/login/components/Login/Login.js
+++ b/src/renderer/login/components/Login/Login.js
@@ -23,7 +23,7 @@ const TABS = {
   [TAB_FILE]: 'Wallet File'
 };
 
-export default class Login extends React.Component {
+export default class Login extends React.PureComponent {
   static propTypes = {
     loading: bool,
     login: func.isRequired

--- a/src/renderer/login/components/LoginFormLedger/LoginFormLedger.js
+++ b/src/renderer/login/components/LoginFormLedger/LoginFormLedger.js
@@ -16,7 +16,7 @@ const deviceInfoShape = shape({
   product: string.isRequired
 });
 
-export default class LoginFormLedger extends React.Component {
+export default class LoginFormLedger extends React.PureComponent {
   static propTypes = {
     poll: func.isRequired,
     publicKey: string,

--- a/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.js
+++ b/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.js
@@ -8,7 +8,7 @@ import Button from 'shared/components/Forms/Button';
 
 import styles from './LoginFormPassphrase.scss';
 
-export default class LoginFormWIF extends React.Component {
+export default class LoginFormWIF extends React.PureComponent {
   static propTypes = {
     disabled: bool,
     passphrase: string,

--- a/src/renderer/login/components/LoginFormWIF/LoginFormWIF.js
+++ b/src/renderer/login/components/LoginFormWIF/LoginFormWIF.js
@@ -7,7 +7,7 @@ import Button from 'shared/components/Forms/Button';
 
 import styles from './LoginFormWIF.scss';
 
-export default class LoginFormWIF extends React.Component {
+export default class LoginFormWIF extends React.PureComponent {
   static propTypes = {
     disabled: bool,
     wif: string,

--- a/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
+++ b/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
@@ -10,7 +10,7 @@ import Input from 'shared/components/Forms/Input/Input';
 
 import styles from './LoginFormWalletFile.scss';
 
-export default class LoginFormWalletFile extends React.Component {
+export default class LoginFormWalletFile extends React.PureComponent {
   static propTypes = {
     disabled: bool,
     encryptedWIF: string,

--- a/src/renderer/logout/components/Logout/Logout.js
+++ b/src/renderer/logout/components/Logout/Logout.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { func } from 'prop-types';
 
-export default class Logout extends React.Component {
+export default class Logout extends React.PureComponent {
   static propTypes = {
     logout: func.isRequired
   };

--- a/src/renderer/register/components/AccountDetails/AccountDatum/AccountDatum.js
+++ b/src/renderer/register/components/AccountDetails/AccountDatum/AccountDatum.js
@@ -10,7 +10,7 @@ import styles from './AccountDatum.scss';
 
 const COPIED_DURATION = 2000;
 
-export default class AccountDatum extends React.Component {
+export default class AccountDatum extends React.PureComponent {
   static propTypes = {
     label: string.isRequired,
     value: string.isRequired

--- a/src/renderer/register/components/AccountDetails/SaveAccount/SaveAccount.js
+++ b/src/renderer/register/components/AccountDetails/SaveAccount/SaveAccount.js
@@ -18,7 +18,7 @@ const FILE_FILTERS = [
   { name: 'NEP6 Wallet File', extensions: ['json'] }
 ];
 
-export default class SaveAccount extends React.Component {
+export default class SaveAccount extends React.PureComponent {
   static propTypes = {
     account: accountShape.isRequired,
     label: string,

--- a/src/renderer/register/components/Register/Register.js
+++ b/src/renderer/register/components/Register/Register.js
@@ -16,7 +16,7 @@ const TABS = {
   [TAB_CREATE]: 'Create Account'
 };
 
-export default class Register extends React.Component {
+export default class Register extends React.PureComponent {
   static propTypes = {
     loading: bool,
     account: accountShape,

--- a/src/renderer/register/components/RegisterForm/RegisterForm.js
+++ b/src/renderer/register/components/RegisterForm/RegisterForm.js
@@ -8,7 +8,7 @@ import Button from 'shared/components/Forms/Button';
 
 import styles from './RegisterForm.scss';
 
-export default class RegisterForm extends React.Component {
+export default class RegisterForm extends React.PureComponent {
   static propTypes = {
     disabled: bool,
     passphrase: string,

--- a/src/renderer/root/components/App/ButtonBar/ButtonBar.js
+++ b/src/renderer/root/components/App/ButtonBar/ButtonBar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { string } from 'prop-types';
 import { remote } from 'electron';
+import { debounce } from 'lodash';
 
 import Icon from 'shared/components/Icon';
 
@@ -21,12 +22,12 @@ export default class ButtonBar extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.updateIsMax();
-    window.addEventListener('resize', this.updateIsMax);
+    this.handleUpdateMaximized();
+    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.updateIsMax);
+    window.removeEventListener('resize', this.handleResize);
   }
 
   render() {
@@ -67,15 +68,17 @@ export default class ButtonBar extends React.PureComponent {
     this.getBrowserWindow().close();
   }
 
-  showWindowIcons = () => {
-    return process.platform !== 'darwin';
-  }
-
-  updateIsMax = () => {
+  handleUpdateMaximized = () => {
     const win = this.getBrowserWindow();
     if (win) {
       this.setState({ isMaximized: win.isMaximized() });
     }
+  }
+
+  handleResize = debounce(this.handleUpdateMaximized, 250)
+
+  showWindowIcons = () => {
+    return process.platform !== 'darwin';
   }
 
   getBrowserWindow = () => {

--- a/src/renderer/root/components/App/ButtonBar/ButtonBar.js
+++ b/src/renderer/root/components/App/ButtonBar/ButtonBar.js
@@ -7,7 +7,7 @@ import Icon from 'shared/components/Icon';
 
 import styles from './ButtonBar.scss';
 
-export default class ButtonBar extends React.Component {
+export default class ButtonBar extends React.PureComponent {
   static propTypes = {
     className: string
   };

--- a/src/renderer/root/components/App/DialogPresenter/DialogPresenter.js
+++ b/src/renderer/root/components/App/DialogPresenter/DialogPresenter.js
@@ -8,7 +8,7 @@ import Confirm from 'shared/components/Confirm';
 import dialogShape from '../../../shapes/dialogShape';
 import { TYPE_ALERT, TYPE_CONFIRM } from '../../../values/dialogs';
 
-export default class AlertPresenter extends React.Component {
+export default class AlertPresenter extends React.PureComponent {
   static propTypes = {
     dialog: dialogShape,
     onClose: func

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
@@ -14,7 +14,7 @@ import styles from './AddressBar.scss';
 
 const RETURN_KEY = 13;
 
-export default class AddressBar extends React.Component {
+export default class AddressBar extends React.PureComponent {
   static propTypes = {
     className: string,
     query: string,

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
@@ -11,7 +11,7 @@ import Navigation from './Navigation';
 import AddressBar from './AddressBar';
 import styles from './AuthenticatedLayout.scss';
 
-export default class AuthenticatedLayout extends React.Component {
+export default class AuthenticatedLayout extends React.PureComponent {
   static propTypes = {
     activeSessionId: string.isRequired,
     tabs: objectOf(tabShape).isRequired,

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
@@ -7,7 +7,7 @@ import Icon from 'shared/components/Icon';
 
 import styles from './Tab.scss';
 
-export default class Tab extends React.Component {
+export default class Tab extends React.PureComponent {
   static propTypes = {
     className: string,
     active: bool,

--- a/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
+++ b/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
@@ -7,7 +7,7 @@ import { INTERNAL, EXTERNAL } from 'browser/values/browserValues';
 
 import styles from './TabLink.scss';
 
-export default class TabLink extends React.Component {
+export default class TabLink extends React.PureComponent {
   static propTypes = {
     className: string,
     type: oneOf([INTERNAL, EXTERNAL]),

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -9,7 +9,7 @@ import tabShape from 'browser/shapes/tabShape';
 import Tab from '../Tab';
 import styles from './Tabs.scss';
 
-export default class Tabs extends React.Component {
+export default class Tabs extends React.PureComponent {
   static propTypes = {
     className: string,
     activeSessionId: string.isRequired,

--- a/src/renderer/root/components/PrivateRoute/PrivateRoute.js
+++ b/src/renderer/root/components/PrivateRoute/PrivateRoute.js
@@ -3,7 +3,7 @@ import { Route, Redirect } from 'react-router-dom';
 import { bool, func } from 'prop-types';
 import { omit } from 'lodash';
 
-export default class PrivateRoute extends React.Component {
+export default class PrivateRoute extends React.PureComponent {
   static propTypes = {
     authenticated: bool,
     component: func.isRequired

--- a/src/renderer/settings/components/GeneralSettings/GeneralSettings.js
+++ b/src/renderer/settings/components/GeneralSettings/GeneralSettings.js
@@ -10,7 +10,7 @@ import SectionTitle from '../SectionTitle';
 import SectionContent from '../SectionContent';
 import styles from './GeneralSettings.scss';
 
-export default class GeneralSettings extends React.Component {
+export default class GeneralSettings extends React.PureComponent {
   static propTypes = {
     currency: string.isRequired,
     setCurrency: func.isRequired

--- a/src/renderer/settings/components/NetworkSettings/NetworkSettings.js
+++ b/src/renderer/settings/components/NetworkSettings/NetworkSettings.js
@@ -13,7 +13,7 @@ import SectionContent from '../SectionContent';
 import { PREDEFINED_NETWORKS, DEFAULT_NET } from '../../values/networks';
 import styles from './NetworkSettings.scss';
 
-export default class NetworkSettings extends React.Component {
+export default class NetworkSettings extends React.PureComponent {
   static propTypes = {
     currentNetwork: string.isRequired,
     setCurrentNetwork: func.isRequired,

--- a/src/renderer/shared/components/Alert/Alert.js
+++ b/src/renderer/shared/components/Alert/Alert.js
@@ -8,7 +8,7 @@ import Button from '../Forms/Button';
 import defaultImage from '../../images/modal-request-icon.png';
 import styles from './Alert.scss';
 
-export default class Alert extends React.Component {
+export default class Alert extends React.PureComponent {
   static propTypes = {
     className: string,
     children: node,

--- a/src/renderer/shared/components/Confirm/Confirm.js
+++ b/src/renderer/shared/components/Confirm/Confirm.js
@@ -8,7 +8,7 @@ import Button from '../Forms/Button';
 import defaultImage from '../../images/modal-request-icon.png';
 import styles from './Confirm.scss';
 
-export default class Confirm extends React.Component {
+export default class Confirm extends React.PureComponent {
   static propTypes = {
     className: string,
     children: node,

--- a/src/renderer/shared/components/Forms/Button/Button.js
+++ b/src/renderer/shared/components/Forms/Button/Button.js
@@ -4,7 +4,7 @@ import { string } from 'prop-types';
 
 import styles from './Button.scss';
 
-export default class Button extends React.Component {
+export default class Button extends React.PureComponent {
   render() {
     return ( // eslint-disable-next-line react/button-has-type
       <button

--- a/src/renderer/shared/components/Forms/Input/Input.js
+++ b/src/renderer/shared/components/Forms/Input/Input.js
@@ -5,7 +5,7 @@ import { omit } from 'lodash';
 
 import styles from './Input.scss';
 
-export default class Input extends React.Component {
+export default class Input extends React.PureComponent {
   static propTypes = {
     className: string,
     id: string.isRequired,

--- a/src/renderer/shared/components/Forms/Select/Select.js
+++ b/src/renderer/shared/components/Forms/Select/Select.js
@@ -5,7 +5,7 @@ import { omit } from 'lodash';
 
 import styles from './Select.scss';
 
-export default class Select extends React.Component {
+export default class Select extends React.PureComponent {
   static propTypes = {
     className: string,
     id: string.isRequired,

--- a/src/renderer/shared/components/Modal/Modal.js
+++ b/src/renderer/shared/components/Modal/Modal.js
@@ -5,7 +5,7 @@ import { string, func, node } from 'prop-types';
 import Portal from '../Portal';
 import styles from './Modal.scss';
 
-export default class Modal extends React.Component {
+export default class Modal extends React.PureComponent {
   static propTypes = {
     className: string,
     children: node,

--- a/src/renderer/shared/components/Portal/Portal.js
+++ b/src/renderer/shared/components/Portal/Portal.js
@@ -5,7 +5,7 @@ import { string, node } from 'prop-types';
 
 import styles from './Portal.scss';
 
-export default class Portal extends React.Component {
+export default class Portal extends React.PureComponent {
   static propTypes = {
     className: string,
     children: node

--- a/src/renderer/shared/components/Tabs/Tabs.js
+++ b/src/renderer/shared/components/Tabs/Tabs.js
@@ -5,7 +5,7 @@ import { map } from 'lodash';
 
 import styles from './Tabs.scss';
 
-export default class Tabs extends React.Component {
+export default class Tabs extends React.PureComponent {
   static propTypes = {
     className: string,
     tabs: objectOf(string).isRequired,

--- a/src/renderer/shared/hocs/withImmediateReset.js
+++ b/src/renderer/shared/hocs/withImmediateReset.js
@@ -13,7 +13,7 @@ const withImmediateReset = (
     [propName]: reset
   });
 
-  class ConditionalCallComponent extends React.Component {
+  class ConditionalCallComponent extends React.PureComponent {
     static propTypes = {
       [propName]: func.isRequired
     };

--- a/src/renderer/shared/hocs/withInitialCall.js
+++ b/src/renderer/shared/hocs/withInitialCall.js
@@ -18,7 +18,7 @@ const withInitialCall = (
   mapPropsToAction = defaultMapPropsToAction,
   { propName = PROGRESS_PROP, strategy = pureStrategy, ...options } = {}
 ) => (Component) => {
-  class ConditionalCallComponent extends React.Component {
+  class ConditionalCallComponent extends React.PureComponent {
     static propTypes = {
       [propName]: string.isRequired
     };

--- a/src/renderer/shared/hocs/withProgressChange.js
+++ b/src/renderer/shared/hocs/withProgressChange.js
@@ -19,7 +19,7 @@ export default function withProgressChange(actions, progress, callback) {
   });
 
   return (Component) => {
-    class WrappedComponent extends React.Component {
+    class WrappedComponent extends React.PureComponent {
       componentWillReceiveProps(nextProps) {
         if (!progresses.includes(this.props[PROGRESS_PROP]) &&
             progresses.includes(nextProps[PROGRESS_PROP])) {


### PR DESCRIPTION
## Description
This is a small improvement for overall rendering performance.

## Motivation and Context
Because we're doing a good job with not modifying props and states directly, we can safely use `React.PureComponent` instead of `React.Component`.

This also debounces window resize events to prevent constant redraws for every incremental resize before drag/drop completes.

## How Has This Been Tested?
Navigating throughout the app to ensure nothing broke, and compared window resize performance.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #355