### PR TITLE
chore(send): restore network for sending assets/tokens

### DIFF
--- a/src/renderer/account/components/SendPanel/index.js
+++ b/src/renderer/account/components/SendPanel/index.js
@@ -4,6 +4,7 @@ import { withData, withActions, withProgress, progressValues } from 'spunky';
 
 import authActions from 'login/actions/authActions';
 import sendActions from 'shared/actions/sendActions';
+import withNetworkData from 'shared/hocs/withNetworkData';
 import withConfirm from 'shared/hocs/withConfirm';
 import withAlert from 'shared/hocs/withAlert';
 import withLoadingProp from 'shared/hocs/withLoadingProp';
@@ -41,6 +42,7 @@ export default compose(
     }
   }),
 
+  withNetworkData(),
   withData(authActions, mapAuthDataToProps),
   withActions(sendActions, mapSendActionsToProps),
 


### PR DESCRIPTION
## Description
This adds the current network as a prop to the SendPanel, which is needed to successfully transfer assets & tokens.

## Motivation and Context
While refactoring the account screen to implement the new designs, I accidentally removed a call needed to inject the current network as a prop into the `SendPanel` component.

## How Has This Been Tested?
Sending NEO on TestNet.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A