### PR TITLE
feat(browser): separate sessions by account address

### DIFF
--- a/__tests__/renderer/browser/index.test.js
+++ b/__tests__/renderer/browser/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { merge } from 'lodash';
 
-import { provideStore, createStore } from 'testHelpers';
+import { provideStore, createStore, spunkyKey, mockSpunkyLoaded } from 'testHelpers';
 
 import { Browser } from 'browser';
 import { EXTERNAL } from 'browser/values/browserValues';
@@ -10,6 +10,12 @@ import DAppContainer from 'browser/components/DAppContainer';
 import Error from 'browser/components/Error';
 
 const initialState = {
+  [spunkyKey]: {
+    auth: mockSpunkyLoaded({
+      address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s',
+      wif: 'L2QTooFoDFyRFTxmtiVHt5CfsXfVnexdbENGDkkrrgTTryiLsPMG'
+    })
+  },
   browser: {
     activeSessionId: 'tab-1',
     tabs: {

--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -12,6 +12,7 @@ import styles from './DAppContainer.scss';
 export default class DAppContainer extends React.PureComponent {
   static propTypes = {
     className: string,
+    address: string.isRequired,
     sessionId: string.isRequired,
     tab: tabShape.isRequired,
     setTabError: func.isRequired,
@@ -98,6 +99,7 @@ export default class DAppContainer extends React.PureComponent {
     return (
       <webview
         ref={this.registerRef}
+        partition={this.props.address}
         preload={this.getPreloadPath()}
         className={classNames(styles.webview, { [styles.hidden]: this.isHidden() })}
       />

--- a/src/renderer/browser/components/DAppContainer/index.js
+++ b/src/renderer/browser/components/DAppContainer/index.js
@@ -1,5 +1,9 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { compose } from 'recompose';
+import { withData } from 'spunky';
+
+import authActions from 'login/actions/authActions';
 
 import DAppContainer from './DAppContainer';
 import { enqueue, dequeue, empty } from '../../actions/requestsActions';
@@ -11,6 +15,8 @@ import {
   openTab,
   closeTab
 } from '../../actions/browserActions';
+
+const mapAuthDataToProps = ({ address }) => ({ address });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   setTabError,
@@ -24,4 +30,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   empty
 }, dispatch);
 
-export default connect(null, mapDispatchToProps)(DAppContainer);
+export default compose(
+  connect(null, mapDispatchToProps),
+  withData(authActions, mapAuthDataToProps)
+)(DAppContainer);


### PR DESCRIPTION
## Description
This implements webview partitions, which ensures that a separate set of sessions, cookies, local storage, etc. are used depending on the currently authenticate NEO address.

## Motivation and Context
If the same client is used for multiple addresses, then separate sessions should be used.

## How Has This Been Tested?
1. Sign into address A.
1. Log into a my.nos.app.
1. Sign out of address A and into address B.
1. Observe my.nos.app is not logged in.
1. Sign out of address B and into address A.
1. Observe my.nos.app is logged in.

## Screenshots (if appropriate)
N/A

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #342