### PR TITLE
chore(browser): open new windows/tabs in nos client

### DIFF
--- a/__tests__/renderer/browser/components/DAppContainer/DAppContainer.test.js
+++ b/__tests__/renderer/browser/components/DAppContainer/DAppContainer.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import uuid from 'uuid/v1';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+import DAppContainer from 'browser/components/DAppContainer/DAppContainer';
+import { EXTERNAL } from 'browser/values/browserValues';
+
+describe('<DAppContainer />', () => {
+  const defaultTab = {
+    type: EXTERNAL,
+    target: 'https://my.nos.app',
+    title: 'My nOS',
+    addressBarEntry: true,
+    loading: false,
+    requestCount: 1,
+    errorCode: null,
+    errorDescription: null
+  };
+
+  const defaultProps = {
+    sessionId: uuid(),
+    tab: defaultTab,
+    setTabError: noop,
+    setTabTitle: noop,
+    setTabTarget: noop,
+    setTabLoaded: noop,
+    enqueue: noop,
+    dequeue: noop,
+    empty: noop,
+    openTab: noop,
+    closeTab: noop
+  };
+
+  const mountContainer = (props = {}) => {
+    return shallow(<DAppContainer {...defaultProps} {...props} />);
+  };
+
+  it('renders a webview', () => {
+    const wrapper = mountContainer();
+    expect(wrapper.find('webview').prop('src')).toEqual(defaultProps.target);
+  });
+});

--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import React from 'react';
 import classNames from 'classnames';
-import { shell } from 'electron';
 import { string, func } from 'prop-types';
 
 import getStaticPath from '../../../util/getStaticPath';
@@ -22,6 +21,7 @@ export default class DAppContainer extends React.PureComponent {
     enqueue: func.isRequired,
     dequeue: func.isRequired,
     empty: func.isRequired,
+    openTab: func.isRequired,
     closeTab: func.isRequired
   }
 
@@ -152,8 +152,7 @@ export default class DAppContainer extends React.PureComponent {
   }
 
   handleNewWindow = (event) => {
-    event.preventDefault();
-    shell.openExternal(event.url);
+    this.props.openTab({ target: event.url });
   }
 
   handleCloseWindow = () => {

--- a/src/renderer/browser/components/DAppContainer/index.js
+++ b/src/renderer/browser/components/DAppContainer/index.js
@@ -2,14 +2,22 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import DAppContainer from './DAppContainer';
-import { setTabError, setTabTitle, setTabTarget, setTabLoaded, closeTab } from '../../actions/browserActions';
 import { enqueue, dequeue, empty } from '../../actions/requestsActions';
+import {
+  setTabError,
+  setTabTitle,
+  setTabTarget,
+  setTabLoaded,
+  openTab,
+  closeTab
+} from '../../actions/browserActions';
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   setTabError,
   setTabTitle,
   setTabTarget,
   setTabLoaded,
+  openTab,
   closeTab,
   enqueue,
   dequeue,


### PR DESCRIPTION
## Description
Links that should open in a new window/tab now open in the nOS client instead of the default browser.

## Motivation and Context
nOS should more or less behave like a normal browser, but with advanced blockchain functionality.  Opening a new window/tab in a different browser doesn't match that expectation.

## How Has This Been Tested?
* Click on links with a `target="_blank"` attribute.
* Cmd+clicking links without a `target` attribute.

## Screenshots (if appropriate)
![new-tab](https://user-images.githubusercontent.com/169093/43368048-58c79998-931c-11e8-97e1-1d2eadc2e66e.gif)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #374