### PR TITLE
chore(browser): add tab separators

### DIFF
--- a/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.scss
@@ -6,7 +6,7 @@
   }
 
   .percent {
-    fill: #9a99a5;
+    fill: $light-text-color;
     font-size: 16px;
     font-weight: 500;
     text-transform: uppercase;

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
@@ -10,6 +10,27 @@
   background: rgba(#fff, 0.4);
   font-size: 12px;
   transition: all 0.2s ease;
+  box-shadow: inset 1px 0 0 $light-text-color;
+
+  &:first-of-type {
+    box-shadow: none;
+  }
+
+  &:last-of-type {
+    &:not(.active) {
+      box-shadow: inset 1px 0 0 $light-text-color,
+                  inset -1px 0 0 $light-text-color;
+    }
+  }
+
+  &.active + &:last-of-type {
+    box-shadow: inset -1px 0 0 $light-text-color;
+  }
+
+  &.active,
+  &.active + & {
+    box-shadow: none;
+  }
 
   &.active,
   &:hover {


### PR DESCRIPTION
## Description
This updates the browser tabs to match the designs.

## Motivation and Context
It was difficult to see where one tab stopped and another started prior to this change.

## How Has This Been Tested?
Opening 3+ tabs and switching between them.

## Screenshots (if appropriate)
<img width="1186" alt="screen shot 2018-07-29 at 11 55 13 am" src="https://user-images.githubusercontent.com/169093/43368656-4976fad8-9326-11e8-9984-73e963775a87.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A