### PR TITLE
feat(browser): restore webview focus when window is focused

### DIFF
--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -32,6 +32,7 @@ export default class DAppContainer extends React.PureComponent {
   async componentDidMount() {
     window.addEventListener('focus', this.handleFocus);
 
+    this.webview.addEventListener('dom-ready', this.handleFocus);
     this.webview.addEventListener('console-message', this.handleConsoleMessage);
     this.webview.addEventListener('ipc-message', this.handleIPCMessage);
     this.webview.addEventListener('new-window', this.handleNewWindow);
@@ -56,6 +57,7 @@ export default class DAppContainer extends React.PureComponent {
   componentWillUnmount() {
     window.removeEventListener('focus', this.handleFocus);
 
+    this.webview.removeEventListener('dom-ready', this.handleFocus);
     this.webview.removeEventListener('console-message', this.handleConsoleMessage);
     this.webview.removeEventListener('ipc-message', this.handleIPCMessage);
     this.webview.removeEventListener('new-window', this.handleNewWindow);

--- a/src/renderer/browser/components/DAppContainer/DAppContainer.js
+++ b/src/renderer/browser/components/DAppContainer/DAppContainer.js
@@ -30,6 +30,8 @@ export default class DAppContainer extends React.PureComponent {
   }
 
   async componentDidMount() {
+    window.addEventListener('focus', this.handleFocus);
+
     this.webview.addEventListener('console-message', this.handleConsoleMessage);
     this.webview.addEventListener('ipc-message', this.handleIPCMessage);
     this.webview.addEventListener('new-window', this.handleNewWindow);
@@ -52,6 +54,8 @@ export default class DAppContainer extends React.PureComponent {
   }
 
   componentWillUnmount() {
+    window.removeEventListener('focus', this.handleFocus);
+
     this.webview.removeEventListener('console-message', this.handleConsoleMessage);
     this.webview.removeEventListener('ipc-message', this.handleIPCMessage);
     this.webview.removeEventListener('new-window', this.handleNewWindow);
@@ -115,6 +119,10 @@ export default class DAppContainer extends React.PureComponent {
         onReject={this.handleReject}
       />
     );
+  }
+
+  handleFocus = () => {
+    this.webview.focus();
   }
 
   handleConsoleMessage = (event) => {


### PR DESCRIPTION
## Description
This is a small quality of life change to:

1. ensure that when the nOS client window loses and regains focus, the current webview also regains focus, and
2. automatically focus the webview when a page is finished loading.

## Motivation and Context
Currently, if a user has a text input (for example) focused in a webpage, and they go to another window to copy something before Alt+Tabbing back to the client, the input they had focused is no longer focused.  Pasting requires another mouse click or tabbing to the element again.

Similarly, when a webpage loads, if the site deems that an input should be autofocused, that doesn't happen since the webview does not have focus.

## How Has This Been Tested?
* Loading pages that have inputs with autofocus (e.g.: https://google.com).
* Opening sites in two tabs, focusing inputs in each, and switching tabs between them.

## Screenshots (if appropriate)
![webview-focus](https://user-images.githubusercontent.com/169093/43425299-c7c948ae-9417-11e8-9216-66074b564802.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A