### PR TITLE
chore(sidebar): fixed navigation icon stoke width

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
@@ -20,15 +20,12 @@
         color: lighten($link-color, 20%);
       }
 
-      &:not(.disabled):focus,
       &:not(.disabled):hover {
         color: lighten($link-color, 20%);
-        stroke: currentColor;
       }
 
       &:not(.disabled):active {
         color: darken($link-color, 20%);
-        stroke: currentColor;
       }
 
       svg {


### PR DESCRIPTION
## Description
This fixes an unintentional stoke width being applied to the sidebar links.  It also removes some focus coloration that doesn't match the designs.

## Motivation and Context
@deanpress has pixel-perfect vision.

## How Has This Been Tested?
Smoke testing.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A