### PR TITLE
chore(layout): fixed sizing for small windows

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
@@ -14,6 +14,7 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
   background-color: $content-bg-color;
 
   header {
+    flex: 0 0 auto;
     display: flex;
     justify-content: stretch;
     align-items: stretch;
@@ -34,10 +35,13 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
   }
 
   main {
+    flex: 1 1 auto;
     display: flex;
+    flex-direction: row;
 
     .sidebar {
       @include sidebar;
+      flex: 0 0 auto;
 
       .logo {
         flex: 0 0 auto;
@@ -55,17 +59,6 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
         @include sidebar;
         flex: 0 0 auto;
       }
-    }
-  }
-
-  main {
-    flex: 1 1 auto;
-    display: flex;
-    flex-direction: row;
-
-    .sidebar {
-      @include sidebar;
-      flex: 0 0 auto;
     }
 
     .container {


### PR DESCRIPTION
## Description
This fixes the layout between the browser tabs and browser itself.

## Motivation and Context
When the client is shrunk to a very small height, the tab bar gets squished, and there's an unwanted overlap between the browser tabs and the browser itself.

## How Has This Been Tested?
Resizing the browser window so it's very short.

## Screenshots (if appropriate)
**Before:**
<img width="1111" alt="screen shot 2018-08-03 at 9 18 55 am" src="https://user-images.githubusercontent.com/169093/43647797-5070bb22-96fe-11e8-8ba4-e82a68af6545.png">

**After:**
<img width="1097" alt="screen shot 2018-08-03 at 9 19 48 am" src="https://user-images.githubusercontent.com/169093/43647827-65712606-96fe-11e8-86a6-cd6e70fe87a6.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A