### PR TITLE
chore(forms): forward component refs to DOM elements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,32 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "__mocks__"
+  - "__tests__"
+  - "config"
+  - "static"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ yarn install && yarn start
 // Testing command
 yarn test
 
+// Testing with debug (repl) command
+yarn test:debug
+
 // Distribution command
 yarn dist
 ```

--- a/__tests__/renderer/shared/components/Forms/Input/Input.test.js
+++ b/__tests__/renderer/shared/components/Forms/Input/Input.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Input from 'shared/components/Forms/Input/Input';
+
+const mountContainer = (props = {}) => {
+  return shallow(<Input {...props} />);
+};
+
+describe('<Input />', () => {
+  it('renders an input', () => {
+    const props = { id: 'name', defaultValue: 'foo' };
+    const wrapper = mountContainer(props);
+    expect(wrapper.type()).toEqual('input');
+    expect(wrapper.props()).toEqual(expect.objectContaining(props));
+  });
+
+  it('applies a custom className', () => {
+    const wrapper = mountContainer({ className: 'passwordField' });
+    expect(wrapper.prop('className').split(' ')).toContain('passwordField');
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/Input/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/Input/index.test.js
@@ -1,22 +1,16 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import Input from 'shared/components/Forms/Input';
+import InputContainer from 'shared/components/Forms/Input';
+import Input from 'shared/components/Forms/Input/Input';
 
 const mountContainer = (props = {}) => {
-  return shallow(<Input {...props} />);
+  return mount(<InputContainer {...props} />);
 };
 
 describe('<Input />', () => {
-  it('renders an input', () => {
-    const props = { id: 'name', defaultValue: 'foo' };
-    const wrapper = mountContainer(props);
-    expect(wrapper.type()).toEqual('input');
-    expect(wrapper.props()).toEqual(expect.objectContaining(props));
-  });
-
-  it('applies a custom className', () => {
-    const wrapper = mountContainer({ className: 'passwordField' });
-    expect(wrapper.prop('className').split(' ')).toContain('passwordField');
+  it('forwards the ref to the component', () => {
+    const wrapper = mountContainer({ ref: React.createRef() });
+    expect(wrapper).toForwardRefTo(Input);
   });
 });

--- a/__tests__/renderer/shared/components/Forms/LabeledInput/LabeledInput.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledInput/LabeledInput.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import LabeledInput from 'shared/components/Forms/LabeledInput/LabeledInput';
+import Label from 'shared/components/Forms/Label';
+import Input from 'shared/components/Forms/Input';
+
+const mountContainer = (props = {}) => {
+  return mount(<LabeledInput {...props} />);
+};
+
+describe('<LabeledInput />', () => {
+  it('renders a label', () => {
+    const wrapper = mountContainer({ id: 'name', label: 'Name' });
+    const label = wrapper.find(Label);
+    expect(label.exists()).toBe(true);
+    expect(label.props()).toEqual(expect.objectContaining({ label: 'Name', htmlFor: 'name' }));
+  });
+
+  it('renders an input', () => {
+    const inputProps = { id: 'pw', type: 'password', defaultValue: 'foo' };
+    const wrapper = mountContainer({ label: 'Password', ...inputProps });
+    const input = wrapper.find(Input);
+    expect(input.exists()).toBe(true);
+    expect(input.props()).toEqual(expect.objectContaining(inputProps));
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
@@ -1,27 +1,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import LabeledInput from 'shared/components/Forms/LabeledInput';
-import Label from 'shared/components/Forms/Label';
-import Input from 'shared/components/Forms/Input';
+import LabeledInputContainer from 'shared/components/Forms/LabeledInput';
+import LabeledInput from 'shared/components/Forms/LabeledInput/LabeledInput';
 
 const mountContainer = (props = {}) => {
-  return mount(<LabeledInput {...props} />);
+  return mount(<LabeledInputContainer {...props} />);
 };
 
 describe('<LabeledInput />', () => {
-  it('renders a label', () => {
-    const wrapper = mountContainer({ id: 'name', label: 'Name' });
-    const label = wrapper.find(Label);
-    expect(label.exists()).toBe(true);
-    expect(label.props()).toEqual(expect.objectContaining({ label: 'Name', htmlFor: 'name' }));
-  });
-
-  it('renders an input', () => {
-    const inputProps = { id: 'pw', type: 'password', defaultValue: 'foo' };
-    const wrapper = mountContainer({ label: 'Password', ...inputProps });
-    const input = wrapper.find(Input);
-    expect(input.exists()).toBe(true);
-    expect(input.props()).toEqual(expect.objectContaining(inputProps));
+  it('forwards the ref to the component', () => {
+    const wrapper = mountContainer({ ref: React.createRef() });
+    expect(wrapper).toForwardRefTo(LabeledInput);
   });
 });

--- a/__tests__/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import LabeledSelect from 'shared/components/Forms/LabeledSelect';
+import Label from 'shared/components/Forms/Label';
+import Select from 'shared/components/Forms/Select';
+
+const mountContainer = (props = {}) => {
+  return mount(<LabeledSelect {...props} />);
+};
+
+describe('<LabeledSelect />', () => {
+  it('renders a label', () => {
+    const wrapper = mountContainer({ id: 'currency', label: 'Currency' });
+    const label = wrapper.find(Label);
+    expect(label.exists()).toBe(true);
+    expect(label.props()).toEqual(expect.objectContaining({ label: 'Currency', htmlFor: 'currency' }));
+  });
+
+  it('renders a select', () => {
+    const children = (
+      <React.Fragment>
+        <option value="USD">United States Dollar</option>
+        <option value="EUR">Euro</option>
+      </React.Fragment>
+    );
+    const wrapper = mountContainer({ id: 'currency', label: 'Currency', children });
+    const select = wrapper.find(Select);
+    expect(select.exists()).toBe(true);
+    expect(select.props()).toEqual(expect.objectContaining({ id: 'currency', children }));
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
@@ -1,32 +1,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import LabeledSelect from 'shared/components/Forms/LabeledSelect';
-import Label from 'shared/components/Forms/Label';
-import Select from 'shared/components/Forms/Select';
+import LabeledSelectContainer from 'shared/components/Forms/LabeledSelect';
+import LabeledSelect from 'shared/components/Forms/LabeledSelect/LabeledSelect';
 
 const mountContainer = (props = {}) => {
-  return mount(<LabeledSelect {...props} />);
+  return mount(<LabeledSelectContainer {...props} />);
 };
 
 describe('<LabeledSelect />', () => {
-  it('renders a label', () => {
-    const wrapper = mountContainer({ id: 'currency', label: 'Currency' });
-    const label = wrapper.find(Label);
-    expect(label.exists()).toBe(true);
-    expect(label.props()).toEqual(expect.objectContaining({ label: 'Currency', htmlFor: 'currency' }));
-  });
-
-  it('renders a select', () => {
-    const children = (
-      <React.Fragment>
-        <option value="USD">United States Dollar</option>
-        <option value="EUR">Euro</option>
-      </React.Fragment>
-    );
-    const wrapper = mountContainer({ id: 'currency', label: 'Currency', children });
-    const select = wrapper.find(Select);
-    expect(select.exists()).toBe(true);
-    expect(select.props()).toEqual(expect.objectContaining({ id: 'currency', children }));
+  it('forwards the ref to the component', () => {
+    const wrapper = mountContainer({ ref: React.createRef() });
+    expect(wrapper).toForwardRefTo(LabeledSelect);
   });
 });

--- a/__tests__/renderer/shared/components/Forms/Select/Select.test.js
+++ b/__tests__/renderer/shared/components/Forms/Select/Select.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Select from 'shared/components/Forms/Select/Select';
+
+const mountContainer = (props = {}) => {
+  return shallow(<Select {...props} />);
+};
+
+describe('<Select />', () => {
+  it('renders a select', () => {
+    const children = (
+      <React.Fragment>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </React.Fragment>
+    );
+    const props = { id: 'name', defaultValue: 'foo', children };
+    const wrapper = mountContainer(props);
+    expect(wrapper.type()).toEqual('select');
+    expect(wrapper.props()).toEqual(expect.objectContaining(props));
+  });
+
+  it('applies a custom className', () => {
+    const wrapper = mountContainer({ className: 'currency' });
+    expect(wrapper.prop('className').split(' ')).toContain('currency');
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/Select/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/Select/index.test.js
@@ -1,28 +1,16 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
-import Select from 'shared/components/Forms/Select';
+import SelectContainer from 'shared/components/Forms/Select';
+import Select from 'shared/components/Forms/Select/Select';
 
 const mountContainer = (props = {}) => {
-  return shallow(<Select {...props} />);
+  return mount(<SelectContainer {...props} />);
 };
 
 describe('<Select />', () => {
-  it('renders a select', () => {
-    const children = (
-      <React.Fragment>
-        <option value="foo">Foo</option>
-        <option value="bar">Bar</option>
-      </React.Fragment>
-    );
-    const props = { id: 'name', defaultValue: 'foo', children };
-    const wrapper = mountContainer(props);
-    expect(wrapper.type()).toEqual('select');
-    expect(wrapper.props()).toEqual(expect.objectContaining(props));
-  });
-
-  it('applies a custom className', () => {
-    const wrapper = mountContainer({ className: 'currency' });
-    expect(wrapper.prop('className').split(' ')).toContain('currency');
+  it('forwards the ref to the component', () => {
+    const wrapper = mountContainer({ ref: React.createRef() });
+    expect(wrapper).toForwardRefTo(Select);
   });
 });

--- a/__tests__/setupFramework.js
+++ b/__tests__/setupFramework.js
@@ -1,3 +1,5 @@
+import { getDisplayName } from 'recompose';
+
 expect.extend({
   toContainObject(received, argument) {
     const pass = this.equals(
@@ -10,6 +12,16 @@ expect.extend({
     const message = pass
       ? () => `expected ${this.utils.printReceived(received)} not to contain object ${this.utils.printExpected(argument)}`
       : () => `expected ${this.utils.printReceived(received)} to contain object ${this.utils.printExpected(argument)}`;
+
+    return { pass, message };
+  },
+
+  toForwardRefTo(received, argument) {
+    const pass = received.find('ForwardRef').find(argument).exists();
+
+    const message = pass
+      ? () => `expected to not forward ref to ${this.utils.printExpected(getDisplayName(argument))}`
+      : () => `expected to forward ref to ${this.utils.printExpected(getDisplayName(argument))}`;
 
     return { pass, message };
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pack": "yarn dist --dir -c.compression=store -c.mac.identity=null",
     "pretest": "yarn run lint && yarn run stylelint",
     "test": "jest",
+    "test:debug": "node inspect ./node_modules/.bin/jest --runInBand",
     "stylelint": "stylelint src/**/*.scss",
     "lint": "eslint --env browser,node,server --ext .jsx,.js --color .",
     "lint:fix": "yarn run lint --fix",

--- a/src/renderer/shared/components/Forms/Button/Button.js
+++ b/src/renderer/shared/components/Forms/Button/Button.js
@@ -1,39 +1,30 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string } from 'prop-types';
+import { string, func } from 'prop-types';
+import { omit } from 'lodash';
 
 import styles from './Button.scss';
 
 export default class Button extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    type: string,
+    forwardedRef: func
+  };
+
+  static defaultProps = {
+    className: null,
+    type: 'button',
+    forwardedRef: null
+  };
+
   render() {
     return ( // eslint-disable-next-line react/button-has-type
       <button
-        {...this.props}
-        ref={this.registerRef}
+        {...omit(this.props, 'forwardedRef')}
+        ref={this.props.forwardedRef}
         className={classNames(styles.button, this.props.className)}
       />
     );
   }
-
-  registerRef = (el) => {
-    this.button = el;
-  }
-
-  focus = () => {
-    this.button.focus();
-  }
-
-  blur = () => {
-    this.button.blur();
-  }
 }
-
-Button.propTypes = {
-  className: string,
-  type: string
-};
-
-Button.defaultProps = {
-  className: null,
-  type: 'button'
-};

--- a/src/renderer/shared/components/Forms/Button/index.js
+++ b/src/renderer/shared/components/Forms/Button/index.js
@@ -1,1 +1,5 @@
-export { default } from './Button';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import Button from './Button';
+
+export default withForwardedRef()(Button);

--- a/src/renderer/shared/components/Forms/Input/Input.js
+++ b/src/renderer/shared/components/Forms/Input/Input.js
@@ -1,24 +1,27 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string } from 'prop-types';
+import { string, func } from 'prop-types';
 
 import styles from './Input.scss';
 
 export default class Input extends React.PureComponent {
   static propTypes = {
-    className: string
+    className: string,
+    forwardedRef: func
   };
 
   static defaultProps = {
-    className: null
+    className: null,
+    forwardedRef: null
   };
 
   render() {
-    const { className, ...passDownProps } = this.props;
+    const { className, forwardedRef, ...passDownProps } = this.props;
 
     return (
       <input
         {...passDownProps}
+        ref={forwardedRef}
         className={classNames(styles.input, className)}
       />
     );

--- a/src/renderer/shared/components/Forms/Input/index.js
+++ b/src/renderer/shared/components/Forms/Input/index.js
@@ -1,1 +1,5 @@
-export { default } from './Input';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import Input from './Input';
+
+export default withForwardedRef()(Input);

--- a/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.js
+++ b/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.js
@@ -6,22 +6,24 @@ import Label from '../Label';
 import Input from '../Input';
 import styles from './LabeledInput.scss';
 
-export default function LabeledInput(props) {
-  const { id, label, labelClass, ...passDownProps } = props;
+export default class LabeledInput extends React.PureComponent {
+  static propTypes = {
+    id: string.isRequired,
+    label: node.isRequired,
+    labelClass: string
+  };
 
-  return (
-    <Label htmlFor={id} label={label} className={classNames(styles.labeledInput, labelClass)}>
-      <Input id={id} {...passDownProps} />
-    </Label>
-  );
+  static defaultProps = {
+    labelClass: null
+  };
+
+  render() {
+    const { id, label, labelClass, ...passDownProps } = this.props;
+
+    return (
+      <Label htmlFor={id} label={label} className={classNames(styles.labeledInput, labelClass)}>
+        <Input id={id} {...passDownProps} />
+      </Label>
+    );
+  }
 }
-
-LabeledInput.propTypes = {
-  id: string.isRequired,
-  label: node.isRequired,
-  labelClass: string
-};
-
-LabeledInput.defaultProps = {
-  labelClass: null
-};

--- a/src/renderer/shared/components/Forms/LabeledInput/index.js
+++ b/src/renderer/shared/components/Forms/LabeledInput/index.js
@@ -1,1 +1,5 @@
-export { default } from './LabeledInput';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import LabeledInput from './LabeledInput';
+
+export default withForwardedRef()(LabeledInput);

--- a/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.js
+++ b/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.js
@@ -6,22 +6,24 @@ import Label from '../Label';
 import Select from '../Select';
 import styles from './LabeledSelect.scss';
 
-export default function LabeledSelect(props) {
-  const { id, label, labelClass, ...passDownProps } = props;
+export default class LabeledSelect extends React.PureComponent {
+  static propTypes = {
+    id: string.isRequired,
+    label: node.isRequired,
+    labelClass: string
+  };
 
-  return (
-    <Label htmlFor={id} label={label} className={classNames(styles.labeledSelect, labelClass)}>
-      <Select id={id} {...passDownProps} />
-    </Label>
-  );
+  static defaultProps = {
+    labelClass: null
+  };
+
+  render() {
+    const { id, label, labelClass, ...passDownProps } = this.props;
+
+    return (
+      <Label htmlFor={id} label={label} className={classNames(styles.labeledSelect, labelClass)}>
+        <Select id={id} {...passDownProps} />
+      </Label>
+    );
+  }
 }
-
-LabeledSelect.propTypes = {
-  id: string.isRequired,
-  label: node.isRequired,
-  labelClass: string
-};
-
-LabeledSelect.defaultProps = {
-  labelClass: null
-};

--- a/src/renderer/shared/components/Forms/LabeledSelect/index.js
+++ b/src/renderer/shared/components/Forms/LabeledSelect/index.js
@@ -1,1 +1,5 @@
-export { default } from './LabeledSelect';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import LabeledSelect from './LabeledSelect';
+
+export default withForwardedRef()(LabeledSelect);

--- a/src/renderer/shared/components/Forms/PrimaryButton/PrimaryButton.js
+++ b/src/renderer/shared/components/Forms/PrimaryButton/PrimaryButton.js
@@ -1,38 +1,29 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string } from 'prop-types';
+import { string, func } from 'prop-types';
+import { omit } from 'lodash';
 
 import Button from '../Button';
 import styles from './PrimaryButton.scss';
 
 export default class PrimaryButton extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    forwardedRef: func
+  };
+
+  static defaultProps = {
+    className: null,
+    forwardedRef: null
+  };
+
   render() {
     return (
       <Button
-        {...this.props}
-        ref={this.registerRef}
+        {...omit(this.props, 'forwardedRef')}
+        ref={this.props.forwardedRef}
         className={classNames(styles.primaryButton, this.props.className)}
       />
     );
   }
-
-  registerRef = (el) => {
-    this.button = el;
-  }
-
-  focus = () => {
-    this.button.focus();
-  }
-
-  blur = () => {
-    this.button.blur();
-  }
 }
-
-PrimaryButton.propTypes = {
-  className: string
-};
-
-PrimaryButton.defaultProps = {
-  className: null
-};

--- a/src/renderer/shared/components/Forms/PrimaryButton/index.js
+++ b/src/renderer/shared/components/Forms/PrimaryButton/index.js
@@ -1,1 +1,5 @@
-export { default } from './PrimaryButton';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import PrimaryButton from './PrimaryButton';
+
+export default withForwardedRef()(PrimaryButton);

--- a/src/renderer/shared/components/Forms/Select/Select.js
+++ b/src/renderer/shared/components/Forms/Select/Select.js
@@ -1,24 +1,28 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string } from 'prop-types';
+import { string, func } from 'prop-types';
 
 import styles from './Select.scss';
 
 export default class Select extends React.PureComponent {
   static propTypes = {
-    className: string
+    className: string,
+    forwardedRef: func
   };
 
   static defaultProps = {
-    className: null
+    className: null,
+    forwardedRef: null
   };
 
   render() {
-    const { className, ...passDownProps } = this.props;
+    const { className, forwardedRef, ...passDownProps } = this.props;
 
     return (
+
       <select
         {...passDownProps}
+        ref={forwardedRef}
         className={classNames(styles.select, className)}
       />
     );

--- a/src/renderer/shared/components/Forms/Select/index.js
+++ b/src/renderer/shared/components/Forms/Select/index.js
@@ -1,1 +1,5 @@
-export { default } from './Select';
+import withForwardedRef from 'shared/hocs/withForwardedRef';
+
+import Select from './Select';
+
+export default withForwardedRef()(Select);

--- a/src/renderer/shared/hocs/withForwardedRef.js
+++ b/src/renderer/shared/hocs/withForwardedRef.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const withForwardedRef = (propName = 'forwardedRef') => (Component) => {
+  return React.forwardRef((props, ref) => {
+    const refProps = { [propName]: ref };
+    return <Component {...props} {...refProps} />;
+  });
+};
+
+export default withForwardedRef;


### PR DESCRIPTION
~~**NOTE:** This PR is blocked until https://github.com/airbnb/enzyme/issues/1604 is fixed via https://github.com/airbnb/enzyme/pull/1592.~~

## Description
This updates our form-based components to forward refs to the actual DOM element.  This makes it so that the component does not need to expose functions specific to any element (e.g.: `focus()`, `blur()`, `value`).

## Motivation and Context
Components should behave in an intuitive manner.

## How Has This Been Tested?
Via the test suite and smoke testing.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A