### PR TITLE
chore(ui): native user interactions

### DIFF
--- a/src/renderer/root/stylesheets/global.scss
+++ b/src/renderer/root/stylesheets/global.scss
@@ -11,6 +11,7 @@ body {
   padding: 0;
   background: $content-bg-color;
   color: #58585a;
+  user-select: none;
 
   font: {
     family: $primary-font-stack;

--- a/src/renderer/root/stylesheets/global.scss
+++ b/src/renderer/root/stylesheets/global.scss
@@ -12,6 +12,7 @@ body {
   background: $content-bg-color;
   color: #58585a;
   user-select: none;
+  cursor: default;
 
   font: {
     family: $primary-font-stack;

--- a/src/renderer/shared/components/Forms/Button/Button.scss
+++ b/src/renderer/shared/components/Forms/Button/Button.scss
@@ -10,7 +10,7 @@
   font-size: 14px;
   text-align: center;
   box-shadow: inset 0 0 0 2px #8bc83c;
-  cursor: pointer;
+  cursor: default;
   -webkit-font-smoothing: antialiased;
 
   &:not([disabled]):hover {

--- a/src/renderer/shared/components/Tabs/Tabs.scss
+++ b/src/renderer/shared/components/Tabs/Tabs.scss
@@ -7,7 +7,7 @@
 
     .tab {
       display: block;
-      cursor: pointer;
+      cursor: default;
       -webkit-font-smoothing: antialiased;
 
       &:not(:last-child) {


### PR DESCRIPTION
## Description
This updates the interface to use the default mouse cursor (rather than the hand/link cursor) everywhere.  It also makes it so that the user can't highlight text in the UI.

These changes do not apply to any content loaded in a webview, where it still behaves like a normal browser.

## Motivation and Context
The UI interactions should behave like a native app, not a web app.

## How Has This Been Tested?
Moving and clicking/dragging the mouse cursor over components in the UI.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A