### PR TITLE
chore(register): clean store between account creations

### DIFF
--- a/__tests__/renderer/shared/hocs/withUnmountReset.test.js
+++ b/__tests__/renderer/shared/hocs/withUnmountReset.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { provideState } from 'testHelpers';
+
+import withUnmountReset from 'shared/hocs/withUnmountReset';
+
+describe('withUnmountReset', () => {
+  const resetSpy = jest.fn(() => ({ type: 'FAKE_TEST_ACTION' }));
+  const actions = { reset: resetSpy };
+
+  // eslint-disable-next-line react/prop-types
+  const WrappedComponent = withUnmountReset(actions)((props) => (
+    <div>{props.children}</div>
+  ));
+
+  it('does not call reset while mounted', () => {
+    mount(provideState(<WrappedComponent />));
+    expect(actions.reset).not.toHaveBeenCalled();
+  });
+
+  it('calls reset when unmounted', () => {
+    const wrapper = mount(provideState(<WrappedComponent />));
+    wrapper.unmount();
+    expect(actions.reset).toHaveBeenCalled();
+  });
+
+  it('passes props to wrapped component', () => {
+    const wrapper = mount(provideState(<WrappedComponent>My content!</WrappedComponent>));
+    expect(wrapper.text()).toContain('My content!');
+  });
+});

--- a/src/renderer/register/components/Register/index.js
+++ b/src/renderer/register/components/Register/index.js
@@ -1,7 +1,7 @@
 import { compose } from 'recompose';
 import { withData } from 'spunky';
 
-import withImmediateReset from 'shared/hocs/withImmediateReset';
+import withUnmountReset from 'shared/hocs/withUnmountReset';
 
 import Register from './Register';
 import createAccountActions from '../../actions/createAccountActions';
@@ -9,6 +9,6 @@ import createAccountActions from '../../actions/createAccountActions';
 const mapAccountDataToProps = (account) => ({ account });
 
 export default compose(
-  withImmediateReset(createAccountActions),
+  withUnmountReset(createAccountActions),
   withData(createAccountActions, mapAccountDataToProps)
 )(Register);

--- a/src/renderer/register/components/Register/index.js
+++ b/src/renderer/register/components/Register/index.js
@@ -1,8 +1,14 @@
+import { compose } from 'recompose';
 import { withData } from 'spunky';
+
+import withImmediateReset from 'shared/hocs/withImmediateReset';
 
 import Register from './Register';
 import createAccountActions from '../../actions/createAccountActions';
 
 const mapAccountDataToProps = (account) => ({ account });
 
-export default withData(createAccountActions, mapAccountDataToProps)(Register);
+export default compose(
+  withImmediateReset(createAccountActions),
+  withData(createAccountActions, mapAccountDataToProps)
+)(Register);

--- a/src/renderer/register/components/RegisterForm/index.js
+++ b/src/renderer/register/components/RegisterForm/index.js
@@ -1,7 +1,6 @@
 import { compose, withState } from 'recompose';
 import { withActions, progressValues } from 'spunky';
 
-import withImmediateReset from 'shared/hocs/withImmediateReset';
 import withLoadingProp from 'shared/hocs/withLoadingProp';
 import { withErrorToast } from 'shared/hocs/withToast';
 import withProgressChange from 'shared/hocs/withProgressChange';
@@ -19,7 +18,6 @@ const mapAccountActionsToProps = (actions) => ({
 });
 
 export default compose(
-  withImmediateReset(createAccountActions),
   withActions(createAccountActions, mapAccountActionsToProps),
   withLoadingProp(createAccountActions, { strategy: pureStrategy }),
 

--- a/src/renderer/shared/hocs/withUnmountReset.js
+++ b/src/renderer/shared/hocs/withUnmountReset.js
@@ -5,10 +5,7 @@ import { omit } from 'lodash';
 
 const RESET_PROP = '__reset__';
 
-const withImmediateReset = (
-  actions,
-  { propName = RESET_PROP, ...options } = {}
-) => (Component) => {
+const withUnmountReset = (actions, { propName = RESET_PROP, ...options } = {}) => (Component) => {
   const mapResetToProps = ({ reset }) => ({
     [propName]: reset
   });
@@ -18,7 +15,7 @@ const withImmediateReset = (
       [propName]: func.isRequired
     };
 
-    componentWillMount() {
+    componentWillUnmount() {
       this.props[propName]();
     }
 
@@ -30,4 +27,4 @@ const withImmediateReset = (
   return withActions(actions, mapResetToProps, { propName, ...options })(ConditionalCallComponent);
 };
 
-export default withImmediateReset;
+export default withUnmountReset;


### PR DESCRIPTION
## Description
This fixes account creation to ensure the correct details are displayed to the user.  Previously, if two subsequent accounts were created, the details of the first one would continue to render instead of the new information.

## Motivation and Context
Newly created account data should be secure, and so it shouldn't be persisted between creations.  The app should also properly reflect the correct information for any use case such as account creation.

## How Has This Been Tested?
Smoke tested by creating multiple subsequent accounts.  Also added tests.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #427