### PR TITLE
chore(navigation): highlight active & focused links

### DIFF
--- a/src/common/stylesheets/mixins.scss
+++ b/src/common/stylesheets/mixins.scss
@@ -1,3 +1,53 @@
+@mixin navigationLink {
+  $link-color: $light-text-color;
+  $icon-color: #8bc83c;
+  $focus-background-color: #e9eaee;
+  $active-background-color: #d7d8de;
+
+  position: relative;
+  display: block;
+  padding: 8px 0;
+  color: $link-color;
+  text-decoration: none;
+  cursor: default;
+
+  &.disabled {
+    color: lighten($link-color, 20%);
+  }
+
+  &:not(.disabled):focus,
+  &:not(.disabled):hover {
+    color: $icon-color;
+    background: $focus-background-color;
+  }
+
+  &:not(.disabled):active {
+    color: $icon-color;
+    background: $active-background-color;
+  }
+
+  &:not(.disabled).active {
+    position: relative;
+    color: $icon-color;
+    background: $active-background-color;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 3px;
+      background: linear-gradient(0deg, #b9d532 0%, #5bba47 100%);
+    }
+  }
+
+  svg {
+    display: block;
+    margin: 0 auto;
+  }
+}
+
 @keyframes spin {
   from {
     -webkit-transform: rotate(0deg);

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
@@ -42,6 +42,8 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
     .sidebar {
       @include sidebar;
       flex: 0 0 auto;
+      display: flex;
+      flex-direction: column;
 
       .logo {
         flex: 0 0 auto;
@@ -55,7 +57,7 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
 
       .navigation {
         @include sidebar;
-        flex: 0 0 auto;
+        flex: 1 1 auto;
       }
     }
 

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -22,23 +22,29 @@ export default function Navigation(props) {
       <ul className={styles.group}>
         <li>
           <Tooltip overlay="DApps">
-            <TabLink id="dapps" target={DAPPS} disabled>
-              <DAppsIcon aria-label="dapps" />
-            </TabLink>
+            <div>
+              <TabLink id="dapps" target={DAPPS} disabled>
+                <DAppsIcon aria-label="dapps" />
+              </TabLink>
+            </div>
           </Tooltip>
         </li>
         <li>
           <Tooltip overlay="Account">
-            <TabLink id="account" target={ACCOUNT}>
-              <AccountIcon aria-label="account" />
-            </TabLink>
+            <div>
+              <TabLink id="account" target={ACCOUNT}>
+                <AccountIcon aria-label="account" />
+              </TabLink>
+            </div>
           </Tooltip>
         </li>
         <li>
           <Tooltip overlay="Settings">
-            <TabLink id="settings" target={SETTINGS}>
-              <SettingsIcon aria-label="settings" />
-            </TabLink>
+            <div>
+              <TabLink id="settings" target={SETTINGS}>
+                <SettingsIcon aria-label="settings" />
+              </TabLink>
+            </div>
           </Tooltip>
         </li>
         <li>

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -6,8 +6,8 @@ import { NavLink } from 'react-router-dom';
 import { string } from 'prop-types';
 import { noop } from 'lodash';
 
-import { DAPPS, ACCOUNT, SETTINGS } from 'browser/values/browserValues';
-import DAppsIcon from 'shared/images/icons/dapps.svg';
+import { /* DAPPS, */ ACCOUNT, SETTINGS } from 'browser/values/browserValues';
+// import DAppsIcon from 'shared/images/icons/dapps.svg';
 import AccountIcon from 'shared/images/icons/account.svg';
 import SettingsIcon from 'shared/images/icons/settings.svg';
 import LogoutIcon from 'shared/images/icons/logout.svg';
@@ -20,15 +20,15 @@ export default function Navigation(props) {
   return (
     <nav className={classNames(styles.navigation, props.className)}>
       <ul className={styles.group}>
-        <li>
+        {/* <li>
           <Tooltip overlay="DApps">
             <div>
-              <TabLink id="dapps" target={DAPPS} disabled>
+              <TabLink id="dapps" target={DAPPS}>
                 <DAppsIcon aria-label="dapps" />
               </TabLink>
             </div>
           </Tooltip>
-        </li>
+        </li> */}
         <li>
           <Tooltip overlay="Account">
             <div>

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -21,32 +21,32 @@ export default function Navigation(props) {
     <nav className={classNames(styles.navigation, props.className)}>
       <ul className={styles.group}>
         <li>
-          <TabLink target={DAPPS} className={styles.link} disabled>
-            <Tooltip id="dapps" overlay="DApps">
+          <Tooltip overlay="DApps">
+            <TabLink id="dapps" target={DAPPS} disabled>
               <DAppsIcon aria-label="dapps" />
-            </Tooltip>
-          </TabLink>
+            </TabLink>
+          </Tooltip>
         </li>
         <li>
-          <TabLink target={ACCOUNT} className={styles.link}>
-            <Tooltip id="account" overlay="Account">
+          <Tooltip overlay="Account">
+            <TabLink id="account" target={ACCOUNT}>
               <AccountIcon aria-label="account" />
-            </Tooltip>
-          </TabLink>
+            </TabLink>
+          </Tooltip>
         </li>
         <li>
-          <TabLink target={SETTINGS} className={styles.link}>
-            <Tooltip id="settings" overlay="Settings">
+          <Tooltip overlay="Settings">
+            <TabLink id="settings" target={SETTINGS}>
               <SettingsIcon aria-label="settings" />
-            </Tooltip>
-          </TabLink>
+            </TabLink>
+          </Tooltip>
         </li>
         <li>
-          <NavLink exact to="/logout" draggable={false} className={styles.link}>
-            <Tooltip id="logout" overlay="Logout">
+          <Tooltip overlay="Logout">
+            <NavLink id="logout" exact to="/logout" draggable={false} className={styles.link}>
               <LogoutIcon aria-label="logout" />
-            </Tooltip>
-          </NavLink>
+            </NavLink>
+          </Tooltip>
         </li>
       </ul>
     </nav>

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
@@ -1,11 +1,24 @@
 .navigation {
-  li {
-    padding: 0 0;
-    margin: 0;
-    text-align: center;
+  display: flex;
 
-    .link {
-      @include navigationLink;
+  ul {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: stretch;
+
+    li {
+      padding: 0 0;
+      margin: 0;
+      text-align: center;
+
+      &:last-child {
+        margin-top: auto;
+      }
+
+      .link {
+        @include navigationLink;
+      }
     }
   }
 }

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
@@ -1,37 +1,15 @@
 .navigation {
-  $link-color: $light-text-color;
-
   ul:not(:first-child) {
     border-top: $primary-border-style;
   }
 
   li {
-    padding: 8px 0;
+    padding: 0 0;
     margin: 0;
     text-align: center;
 
     .link {
-      display: block;
-      color: $link-color;
-      text-decoration: none;
-      cursor: default;
-
-      &.disabled {
-        color: lighten($link-color, 20%);
-      }
-
-      &:not(.disabled):hover {
-        color: lighten($link-color, 20%);
-      }
-
-      &:not(.disabled):active {
-        color: darken($link-color, 20%);
-      }
-
-      svg {
-        display: block;
-        margin: 0 auto;
-      }
+      @include navigationLink;
     }
   }
 }

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
@@ -1,8 +1,4 @@
 .navigation {
-  ul:not(:first-child) {
-    border-top: $primary-border-style;
-  }
-
   li {
     padding: 0 0;
     margin: 0;

--- a/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
+++ b/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
@@ -12,6 +12,7 @@ export default class TabLink extends React.PureComponent {
     className: string,
     type: oneOf([INTERNAL, EXTERNAL]),
     target: string.isRequired,
+    active: bool,
     disabled: bool,
     children: node,
     openTab: func
@@ -20,15 +21,21 @@ export default class TabLink extends React.PureComponent {
   static defaultProps = {
     className: null,
     type: INTERNAL,
+    active: false,
     disabled: false,
     children: null,
     openTab: noop
   };
 
   render() {
+    const className = classNames(this.props.className, styles.tabLink, {
+      [styles.active]: this.props.active,
+      [styles.disabled]: this.props.disabled
+    });
+
     return (
       <span
-        className={classNames(this.props.className, styles.tabLink)}
+        className={className}
         role="button"
         tabIndex="0"
         onClick={this.handleClick}

--- a/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.scss
@@ -1,3 +1,3 @@
 .tabLink {
-  // TODO
+  @include navigationLink;
 }

--- a/src/renderer/root/components/AuthenticatedLayout/TabLink/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/TabLink/index.js
@@ -5,6 +5,12 @@ import { openTab } from 'browser/actions/browserActions';
 
 import TabLink from './TabLink';
 
+const mapStateToProps = (state, props) => {
+  const { tabs, activeSessionId } = state.browser;
+  const active = props.target === tabs[activeSessionId].target;
+  return { active };
+};
+
 const mapDispatchToProps = (dispatch) => bindActionCreators({ openTab }, dispatch);
 
-export default connect(null, mapDispatchToProps)(TabLink);
+export default connect(mapStateToProps, mapDispatchToProps)(TabLink);


### PR DESCRIPTION
## Description
This adds highlighting to the active navigation link.  It also moves the logout link to the bottom of the sidebar & hides the dApp link (for now).

## Motivation and Context
Matches designs.

## How Has This Been Tested?
Navigating between links both via the sidebar links and via already opened tabs.

## Screenshots (if appropriate)
![navigation](https://user-images.githubusercontent.com/169093/43998722-2649f79e-9dc2-11e8-94b6-5dcbbe04e767.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #405