### PR TITLE
chore(tabs): replaced z-index with clip-path

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
@@ -24,7 +24,7 @@
   height: 42px;
   background: #fff;
   box-shadow: 0 2px 6px rgba(30, 27, 82, 0.12);
-  z-index: 0;
+  clip-path: inset(0px -6px -6px -6px);
 
   input {
     flex: 1 1 auto;

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
@@ -19,12 +19,14 @@
 }
 
 .addressBar {
+  $shadow-size: 6px;
+
   display: flex;
   align-items: center;
   height: 42px;
   background: #fff;
-  box-shadow: 0 2px 6px rgba(30, 27, 82, 0.12);
-  clip-path: inset(0px -6px -6px -6px);
+  box-shadow: 0 2px $shadow-size rgba(30, 27, 82, 0.12);
+  clip-path: inset(0px (-$shadow-size) (-$shadow-size) (-$shadow-size));
 
   input {
     flex: 1 1 auto;

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
@@ -17,11 +17,6 @@
     box-shadow: none;
   }
 
-  &.active,
-  &:hover {
-    z-index: 1; // stay on top of `AddressBar` box-shadow
-  }
-
   &:last-of-type {
     &:not(.active) {
       box-shadow: inset 1px 0 0 $light-text-color,


### PR DESCRIPTION
## Description
This fixes tabs appearing above the page overlay when displaying modals.

## Motivation and Context
A z-index was being used on the `AddressBar` component to prevent its drop-shadow from extending upward onto the `Tabs` above it.  This had an unintended effect of displaying it above everything else since nothing else had a z-index property.  To fix it, I replaced it with the `clip-path` property, which is kind of like a bounded `overflow` region.

## How Has This Been Tested?
Smoke testing on macOS and observing now shadow extending above the active tab.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #368