### PR TITLE
feat(settings): sidebar navigation

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,6 +4,7 @@
     "function-url-quotes": "always",
     "number-leading-zero": "always",
     "max-nesting-depth": 4,
-    "function-name-case": "lower"
+    "function-name-case": "lower",
+    "no-descending-specificity": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "16.4.2",
     "react-redux": "5.0.7",
     "react-router-dom": "4.3.1",
+    "react-scroll": "1.7.10",
     "recharts": "1.1.0",
     "recompose": "0.28.2",
     "redux": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-redux": "5.0.7",
     "react-router-dom": "4.3.1",
     "react-scroll": "1.7.10",
+    "react-sticky": "6.0.3",
     "recharts": "1.1.0",
     "recompose": "0.28.2",
     "redux": "3.7.2",

--- a/src/renderer/settings/components/GeneralSettings/GeneralSettings.scss
+++ b/src/renderer/settings/components/GeneralSettings/GeneralSettings.scss
@@ -2,6 +2,7 @@
   .input {
     display: flex;
     align-items: center;
+    margin-bottom: 0;
 
     .label {
       flex: 0 1 230px;

--- a/src/renderer/settings/components/SectionContent/SectionContent.scss
+++ b/src/renderer/settings/components/SectionContent/SectionContent.scss
@@ -1,5 +1,5 @@
 .sectionContent {
-  margin-bottom: 40px;
+  padding-bottom: 40px;
   color: #494759;
   font-size: 14px;
 }

--- a/src/renderer/settings/components/Settings/Settings.js
+++ b/src/renderer/settings/components/Settings/Settings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Element, scrollSpy } from 'react-scroll';
+import { StickyContainer, Sticky } from 'react-sticky';
 
 import Page from 'shared/components/Page';
 import Panel from 'shared/components/Panel';
@@ -16,22 +17,26 @@ export default class Settings extends React.PureComponent {
 
   render() {
     return (
-      <div id="settingsContainer" className={styles.settings}>
-        <Page className={styles.page} id="settingsContainer">
+      <StickyContainer id="settingsContainer" className={styles.settings}>
+        <Page className={styles.page}>
           <Panel className={styles.panel}>
             <div className={styles.sidebar}>
-              <ul>
-                <li>
-                  <SidebarLink to="general" containerId="settingsContainer" offset={-24}>
-                    General
-                  </SidebarLink>
-                </li>
-                <li>
-                  <SidebarLink to="network" containerId="settingsContainer" offset={-24}>
-                    Network
-                  </SidebarLink>
-                </li>
-              </ul>
+              <Sticky relative>
+                {({ style }) => (
+                  <ul style={style}>
+                    <li>
+                      <SidebarLink to="general" containerId="settingsContainer">
+                        General
+                      </SidebarLink>
+                    </li>
+                    <li>
+                      <SidebarLink to="network" containerId="settingsContainer">
+                        Network
+                      </SidebarLink>
+                    </li>
+                  </ul>
+                )}
+              </Sticky>
             </div>
 
             <div className={styles.content}>
@@ -44,7 +49,7 @@ export default class Settings extends React.PureComponent {
             </div>
           </Panel>
         </Page>
-      </div>
+      </StickyContainer>
     );
   }
 }

--- a/src/renderer/settings/components/Settings/Settings.js
+++ b/src/renderer/settings/components/Settings/Settings.js
@@ -11,17 +11,22 @@ import SidebarLink from '../SidebarLink';
 import styles from './Settings.scss';
 
 export default class Settings extends React.PureComponent {
+  state = {
+    offset: 0
+  };
+
   componentDidMount() {
+    this.setState({ offset: this.container.node.offsetTop });
     scrollSpy.update();
   }
 
   render() {
     return (
-      <StickyContainer id="settingsContainer" className={styles.settings}>
+      <StickyContainer id="settingsContainer" ref={this.registerRef} className={styles.settings}>
         <Page className={styles.page}>
           <Panel className={styles.panel}>
             <div className={styles.sidebar}>
-              <Sticky relative>
+              <Sticky relative topOffset={this.state.offset}>
                 {({ style }) => (
                   <ul style={style}>
                     <li>
@@ -51,5 +56,9 @@ export default class Settings extends React.PureComponent {
         </Page>
       </StickyContainer>
     );
+  }
+
+  registerRef = (el) => {
+    this.container = el;
   }
 }

--- a/src/renderer/settings/components/Settings/Settings.js
+++ b/src/renderer/settings/components/Settings/Settings.js
@@ -1,19 +1,50 @@
 import React from 'react';
+import { Element, scrollSpy } from 'react-scroll';
 
 import Page from 'shared/components/Page';
 import Panel from 'shared/components/Panel';
 
 import GeneralSettings from '../GeneralSettings';
 import NetworkSettings from '../NetworkSettings';
+import SidebarLink from '../SidebarLink';
 import styles from './Settings.scss';
 
-export default function Settings() {
-  return (
-    <Page className={styles.settings}>
-      <Panel className={styles.panel}>
-        <GeneralSettings />
-        <NetworkSettings />
-      </Panel>
-    </Page>
-  );
+export default class Settings extends React.PureComponent {
+  componentDidMount() {
+    scrollSpy.update();
+  }
+
+  render() {
+    return (
+      <div id="settingsContainer" className={styles.settings}>
+        <Page className={styles.page} id="settingsContainer">
+          <Panel className={styles.panel}>
+            <div className={styles.sidebar}>
+              <ul>
+                <li>
+                  <SidebarLink to="general" containerId="settingsContainer" offset={-24}>
+                    General
+                  </SidebarLink>
+                </li>
+                <li>
+                  <SidebarLink to="network" containerId="settingsContainer" offset={-24}>
+                    Network
+                  </SidebarLink>
+                </li>
+              </ul>
+            </div>
+
+            <div className={styles.content}>
+              <Element name="general">
+                <GeneralSettings />
+              </Element>
+              <Element name="network">
+                <NetworkSettings />
+              </Element>
+            </div>
+          </Panel>
+        </Page>
+      </div>
+    );
+  }
 }

--- a/src/renderer/settings/components/Settings/Settings.scss
+++ b/src/renderer/settings/components/Settings/Settings.scss
@@ -32,4 +32,10 @@
   .content {
     padding: 0 40px;
   }
+
+  @media only screen and (max-width: $responsive-width) {
+    .sidebar {
+      display: none;
+    }
+  }
 }

--- a/src/renderer/settings/components/Settings/Settings.scss
+++ b/src/renderer/settings/components/Settings/Settings.scss
@@ -1,7 +1,35 @@
 .settings {
-  padding: 24px;
+  position: relative;
+  height: 100%;
+  overflow-y: auto;
+
+  .page {
+    padding: 24px;
+  }
 
   .panel {
-    padding: 0 40px 20px;
+    display: flex;
+
+    .sidebar {
+      flex: 0 0 auto;
+    }
+
+    .content {
+      flex: 1 1 auto;
+    }
+  }
+
+  .sidebar {
+    width: 170px;
+    box-shadow: inset -1px 0px 0px #d7d8de;
+
+    ul {
+      list-style: none;
+      margin: 0;
+    }
+  }
+
+  .content {
+    padding: 0 40px;
   }
 }

--- a/src/renderer/settings/components/SidebarLink/SidebarLink.js
+++ b/src/renderer/settings/components/SidebarLink/SidebarLink.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-scroll';
+
+import styles from './SidebarLink.scss';
+
+export default function SidebarLink(props) {
+  return (
+    <Link
+      className={styles.sidebarLink}
+      activeClass={styles.active}
+      spy
+      smooth
+      duration={250}
+      {...props}
+    />
+  );
+}

--- a/src/renderer/settings/components/SidebarLink/SidebarLink.scss
+++ b/src/renderer/settings/components/SidebarLink/SidebarLink.scss
@@ -1,0 +1,31 @@
+.sidebarLink {
+  display: block;
+  height: 42px;
+  line-height: 42px;
+  padding: 0 16px;
+  color: $light-text-color;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-font-smoothing: antialiased;
+
+  &.active,
+  &:hover {
+    color: $dark-text-color;
+  }
+
+  &.active {
+    position: relative;
+
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: 2px;
+      background: linear-gradient(0deg, #b9d532 0%, #5bba47 100%);
+    }
+  }
+}

--- a/src/renderer/settings/components/SidebarLink/index.js
+++ b/src/renderer/settings/components/SidebarLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './SidebarLink';

--- a/src/renderer/shared/components/Page/Page.js
+++ b/src/renderer/shared/components/Page/Page.js
@@ -1,23 +1,19 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string, node } from 'prop-types';
+import { string } from 'prop-types';
 
 import styles from './Page.scss';
 
 export default function Page(props) {
   return (
-    <div className={classNames(styles.page, props.className)}>
-      {props.children}
-    </div>
+    <div {...props} className={classNames(styles.page, props.className)} />
   );
 }
 
 Page.propTypes = {
-  className: string,
-  children: node
+  className: string
 };
 
 Page.defaultProps = {
-  className: null,
-  children: null
+  className: null
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7656,7 +7656,7 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
-raf@^3.2.0, raf@^3.4.0:
+raf@^3.2.0, raf@^3.3.0, raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -7872,6 +7872,13 @@ react-smooth@1.0.0:
     prop-types "^15.6.0"
     raf "^3.2.0"
     react-transition-group "^2.2.1"
+
+react-sticky@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
+  dependencies:
+    prop-types "^15.5.8"
+    raf "^3.3.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5843,6 +5843,10 @@ lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -7852,6 +7856,13 @@ react-router@^4.3.1:
     path-to-regexp "^1.7.0"
     prop-types "^15.6.1"
     warning "^4.0.1"
+
+react-scroll@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.10.tgz#b59cfa11a899a362c6489607ed5865c9c5fd0b53"
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.5.8"
 
 react-smooth@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description
This implements the sidebar navigation from the designs.

* The sidebar links are clickable, and if the section is off the screen, will smoothly scroll into view.
* The sidebar will automatically highlight the section that is active when scrolling.
* The sidebar links are sticky so as to not be lost when scrolling.
* The settings screen is responsive and will hide the sidebar for narrow windows.

## Motivation and Context
Implement new designs.

## How Has This Been Tested?
Smoke testing.

## Screenshots (if appropriate)
![settings-sidebar](https://user-images.githubusercontent.com/169093/44294366-43527080-a25b-11e8-9017-aca083c1d69a.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #403 