### PR TITLE
chore(tests): fixed unexpected router key warning

### DIFF
--- a/__tests__/renderer/root/components/App/Routes/index.test.js
+++ b/__tests__/renderer/root/components/App/Routes/index.test.js
@@ -55,21 +55,17 @@ const openTab = (wrapper, index) => {
 };
 
 describe('<Routes />', () => {
-  describe('browser route', () => {
-    const routerState = { router: { location: { pathname: '/browser', search: '', hash: '' } } };
+  it('changes tabs', () => {
+    const wrapper = mountRoutes();
+    openTab(wrapper, 1);
+    expect(wrapper.find(Tab).at(0).prop('active')).toBe(false);
+    expect(wrapper.find(Tab).at(1).prop('active')).toBe(true);
+  });
 
-    it('changes tabs', () => {
-      const wrapper = mountRoutes(routerState);
-      openTab(wrapper, 1);
-      expect(wrapper.find(Tab).at(0).prop('active')).toBe(false);
-      expect(wrapper.find(Tab).at(1).prop('active')).toBe(true);
-    });
-
-    it('does not remove the webview from the DOM when changing tabs', () => {
-      const wrapper = mountRoutes(routerState);
-      expect(wrapper.find('webview')).toHaveLength(2);
-      openTab(wrapper, 1);
-      expect(wrapper.find('webview')).toHaveLength(2);
-    });
+  it('does not remove the webview from the DOM when changing tabs', () => {
+    const wrapper = mountRoutes();
+    expect(wrapper.find('webview')).toHaveLength(2);
+    openTab(wrapper, 1);
+    expect(wrapper.find('webview')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Description
Fixes a console warning that began after switching to connected-react-router.

## Motivation and Context
>     console.error node_modules/redux/lib/utils/warning.js:14
>       Unexpected key "router" found in preloadedState argument passed to createStore.
>       Expected to find one of the known reducer keys instead: "spunky", "dialogs",
>       "browser", "requests", "toasts". Unexpected keys will be ignored.

## How Has This Been Tested?
```bash
yarn test
```

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A