### PR TITLE
chore(style): treat tabbed content like web ux

### DIFF
--- a/src/common/stylesheets/mixins.scss
+++ b/src/common/stylesheets/mixins.scss
@@ -50,6 +50,15 @@
   }
 }
 
+@mixin webComponent {
+  user-select: auto;
+  cursor: pointer;
+
+  &[disabled] {
+    cursor: not-allowed;
+  }
+}
+
 @keyframes spin {
   from {
     -webkit-transform: rotate(0deg);

--- a/src/renderer/account/components/TransactionsPanel/Receive/Receive.scss
+++ b/src/renderer/account/components/TransactionsPanel/Receive/Receive.scss
@@ -17,6 +17,7 @@
   }
 
   .copy {
+    @include webComponent;
     margin: 10px 0 30px;
   }
 

--- a/src/renderer/account/components/TransactionsPanel/Send/Send.scss
+++ b/src/renderer/account/components/TransactionsPanel/Send/Send.scss
@@ -2,6 +2,7 @@
   margin: 20px 0 0;
 
   .next {
+    @include webComponent;
     display: block;
     width: 100%;
   }

--- a/src/renderer/account/components/TransactionsPanel/TransactionsPanel.scss
+++ b/src/renderer/account/components/TransactionsPanel/TransactionsPanel.scss
@@ -6,6 +6,7 @@
     display: flex;
 
     .tab {
+      @include webComponent;
       flex: 1 0 auto;
     }
   }

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
@@ -74,6 +74,8 @@ $sidebar-shadow: inset -1px 0 0 #d7d8de;
         flex: 1 1 100%;
         box-sizing: border-box;
         overflow-y: auto;
+        user-select: auto;
+        cursor: auto;
       }
 
       .footer {

--- a/src/renderer/settings/components/NetworkSettings/NetworkSettings.scss
+++ b/src/renderer/settings/components/NetworkSettings/NetworkSettings.scss
@@ -13,6 +13,7 @@
     flex-direction: row;
 
     .action {
+      @include webComponent;
       flex-grow: 1;
       margin-right: 2px;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

<!--- Describe your changes in detail -->
## Description
This updates the settings & account tabs to treat the mouse cursor and user selection like a normal browser.

## Motivation and Context
Anything that renders within a tab should behave like web content.

## How Has This Been Tested?
Smoke testing buttons, tabs, etc. between login screen vs. account & settings tabs.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #450