### PR TITLE
chore(account): fixed TypeError for accounts with 3+ tokens

### DIFF
--- a/config/webpack.renderer.js
+++ b/config/webpack.renderer.js
@@ -58,11 +58,22 @@ function replaceSvgLoader(config) {
   });
 }
 
+function replaceUglifyPlugin(config) {
+  const uglify = find(config.plugins, (plugin) => plugin.constructor.name === 'UglifyJsPlugin');
+
+  // Don't inline single-use functions.  Prevents `TypeError: Assignment to constant variable`.
+  // REF: https://github.com/mishoo/UglifyJS2/issues/2842
+  uglify.options.uglifyOptions.compress.inline = 1;
+
+  return config;
+}
+
 module.exports = async (env) => {
   const config = await webpackRenderer(env);
 
   return flow(
     replaceSassLoader,
-    replaceSvgLoader
+    replaceSvgLoader,
+    replaceUglifyPlugin
   )(config);
 };

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
@@ -12,7 +12,7 @@ import styles from './Breakdown.scss';
 
 const COLORS = ['#5ebb46', '#b5d433', '#0b99e3'];
 
-function reduceOthers(data) {
+function reduceSum(data) {
   return reduce(data, (sum, datum) => sum + datum.value, 0);
 }
 
@@ -74,13 +74,12 @@ export default class Breakdown extends React.PureComponent {
 
     return [
       ...data.splice(0, 2),
-      { label: 'OTHERS', value: reduceOthers(data) }
+      { label: 'OTHERS', value: reduceSum(data) }
     ];
   }
 
   getTotalValue = () => {
-    const value = reduce(this.props.data, (sum, datum) => sum + datum.value, 0);
-    return this.formatValue(value);
+    return this.formatValue(reduceSum(this.props.data));
   }
 
   formatValue = (value) => {


### PR DESCRIPTION
## Description
This fixes an issue with the distributable version (via `yarn dist`) that caused the app crash when opening the Account screen.

## Motivation and Context
The app crashes when trying to render the breakdown chart with 3+ tokens.  The error is:

> TypeError: Assignment to constant variable.

This is caused by the uglify plugin inlining single-use functions, as discovered here: https://github.com/mishoo/UglifyJS2/issues/2842#issuecomment-359722583

## How Has This Been Tested?
1. Use `yarn dist` to create a distributable version of the app.
2. Run the app, and login with an account that has 3+ distinct token balances.
3. Observe the app "crash" (HTML output disappears).

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A