### PR TITLE
chore(nav): restore dapps link

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -6,8 +6,8 @@ import { NavLink } from 'react-router-dom';
 import { string } from 'prop-types';
 import { noop } from 'lodash';
 
-import { /* DAPPS, */ ACCOUNT, SETTINGS } from 'browser/values/browserValues';
-// import DAppsIcon from 'shared/images/icons/dapps.svg';
+import { DAPPS, ACCOUNT, SETTINGS } from 'browser/values/browserValues';
+import DAppsIcon from 'shared/images/icons/dapps.svg';
 import AccountIcon from 'shared/images/icons/account.svg';
 import SettingsIcon from 'shared/images/icons/settings.svg';
 import LogoutIcon from 'shared/images/icons/logout.svg';
@@ -20,15 +20,15 @@ export default function Navigation(props) {
   return (
     <nav className={classNames(styles.navigation, props.className)}>
       <ul className={styles.group}>
-        {/* <li>
+        <li>
           <Tooltip overlay="DApps">
             <div>
-              <TabLink id="dapps" target={DAPPS}>
+              <TabLink id="dapps" target={DAPPS} disabled>
                 <DAppsIcon aria-label="dapps" />
               </TabLink>
             </div>
           </Tooltip>
-        </li> */}
+        </li>
         <li>
           <Tooltip overlay="Account">
             <div>

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -21,7 +21,7 @@ export default function Navigation(props) {
     <nav className={classNames(styles.navigation, props.className)}>
       <ul className={styles.group}>
         <li>
-          <Tooltip overlay="DApps">
+          <Tooltip overlay="dApps">
             <div>
               <TabLink id="dapps" target={DAPPS} disabled>
                 <DAppsIcon aria-label="dapps" />


### PR DESCRIPTION
## Description
Restores the "DApps" link in the sidebar, but makes it disabled.

## Motivation and Context
@deanpress felt that the sidebar looked too barren without it, and also wants users to be able to see what features to expect.

## How Has This Been Tested?
Smoke testing.

## Screenshots (if appropriate)
![screen shot 2018-08-18 at 12 51 48 pm](https://user-images.githubusercontent.com/169093/44301942-95d86f00-a2e5-11e8-818e-73a217559793.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A