### PR TITLE
chore(form): separate label into its own component

### DIFF
--- a/__tests__/renderer/shared/components/Forms/Input/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/Input/index.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Input from 'shared/components/Forms/Input';
+
+const mountContainer = (props = {}) => {
+  return shallow(<Input {...props} />);
+};
+
+describe('<Input />', () => {
+  it('renders an input', () => {
+    const props = { id: 'name', defaultValue: 'foo' };
+    const wrapper = mountContainer(props);
+    expect(wrapper.type()).toEqual('input');
+    expect(wrapper.props()).toEqual(expect.objectContaining(props));
+  });
+
+  it('applies a custom className', () => {
+    const wrapper = mountContainer({ className: 'passwordField' });
+    expect(wrapper.prop('className').split(' ')).toContain('passwordField');
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/Label/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/Label/index.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Label from 'shared/components/Forms/Label';
+
+const mountContainer = (props = {}) => {
+  return shallow(<Label {...props} />);
+};
+
+describe('<Label />', () => {
+  it('renders a label', () => {
+    const wrapper = mountContainer({ label: 'Name', htmlFor: 'name' });
+    expect(wrapper.type()).toEqual('label');
+    expect(wrapper.props()).toEqual(expect.objectContaining({ htmlFor: 'name' }));
+    expect(wrapper.text()).toEqual('Name');
+  });
+
+  it('applies a custom className', () => {
+    const wrapper = mountContainer({ label: 'Name', className: 'green' });
+    expect(wrapper.prop('className').split(' ')).toContain('green');
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import LabeledInput from 'shared/components/Forms/LabeledInput';
+
+const mountContainer = (props = {}) => {
+  return mount(<LabeledInput {...props} />);
+};
+
+describe('<LabeledInput />', () => {
+  it('renders a label', () => {
+    const wrapper = mountContainer({ id: 'name', label: 'Name' });
+    const label = wrapper.find('Label');
+    expect(label.exists()).toBe(true);
+    expect(label.props()).toEqual(expect.objectContaining({ label: 'Name', htmlFor: 'name' }));
+  });
+
+  it('renders an input', () => {
+    const inputProps = { id: 'pw', type: 'password', defaultValue: 'foo' };
+    const wrapper = mountContainer({ label: 'Password', ...inputProps });
+    const input = wrapper.find('Input');
+    expect(input.exists()).toBe(true);
+    expect(input.props()).toEqual(expect.objectContaining(inputProps));
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import LabeledSelect from 'shared/components/Forms/LabeledSelect';
+
+const mountContainer = (props = {}) => {
+  return mount(<LabeledSelect {...props} />);
+};
+
+describe('<LabeledSelect />', () => {
+  it('renders a label', () => {
+    const wrapper = mountContainer({ id: 'currency', label: 'Currency' });
+    const label = wrapper.find('Label');
+    expect(label.exists()).toBe(true);
+    expect(label.props()).toEqual(expect.objectContaining({ label: 'Currency', htmlFor: 'currency' }));
+  });
+
+  it('renders a select', () => {
+    const children = (
+      <React.Fragment>
+        <option value="USD">United States Dollar</option>
+        <option value="EUR">Euro</option>
+      </React.Fragment>
+    );
+    const wrapper = mountContainer({ id: 'currency', label: 'Currency', children });
+    const select = wrapper.find('Select');
+    expect(select.exists()).toBe(true);
+    expect(select.props()).toEqual(expect.objectContaining({ id: 'currency', children }));
+  });
+});

--- a/__tests__/renderer/shared/components/Forms/Select/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/Select/index.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Select from 'shared/components/Forms/Select';
+
+const mountContainer = (props = {}) => {
+  return shallow(<Select {...props} />);
+};
+
+describe('<Select />', () => {
+  it('renders a select', () => {
+    const children = (
+      <React.Fragment>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </React.Fragment>
+    );
+    const props = { id: 'name', defaultValue: 'foo', children };
+    const wrapper = mountContainer(props);
+    expect(wrapper.type()).toEqual('select');
+    expect(wrapper.props()).toEqual(expect.objectContaining(props));
+  });
+
+  it('applies a custom className', () => {
+    const wrapper = mountContainer({ className: 'currency' });
+    expect(wrapper.prop('className').split(' ')).toContain('currency');
+  });
+});

--- a/src/renderer/account/components/TransactionsPanel/Send/Send.js
+++ b/src/renderer/account/components/TransactionsPanel/Send/Send.js
@@ -6,8 +6,8 @@ import { BigNumber } from 'bignumber.js';
 import { map, noop } from 'lodash';
 
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
-import Input from 'shared/components/Forms/Input';
-import Select from 'shared/components/Forms/Select';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
+import LabeledSelect from 'shared/components/Forms/LabeledSelect';
 
 import isNumeric from '../../../util/isNumeric';
 import balanceShape from '../../../shapes/balanceShape';
@@ -45,7 +45,7 @@ export default class Send extends React.PureComponent {
 
     return (
       <form className={classNames(styles.send, className)}>
-        <Select
+        <LabeledSelect
           className={styles.asset}
           id="asset"
           label="Token to send"
@@ -53,8 +53,8 @@ export default class Send extends React.PureComponent {
           onChange={this.handleChangeAsset}
         >
           {this.renderAssets()}
-        </Select>
-        <Input
+        </LabeledSelect>
+        <LabeledInput
           className={styles.amount}
           id="amount"
           type="number"
@@ -65,7 +65,7 @@ export default class Send extends React.PureComponent {
           value={amount}
           onChange={this.handleChangeAmount}
         />
-        <Input
+        <LabeledInput
           className={styles.recipient}
           id="recipient"
           label="Recipient"

--- a/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.js
+++ b/src/renderer/login/components/LoginFormPassphrase/LoginFormPassphrase.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { bool, string, func } from 'prop-types';
 import { noop } from 'lodash';
 
-import Input from 'shared/components/Forms/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
 
 import styles from './LoginFormPassphrase.scss';
@@ -32,7 +32,7 @@ export default class LoginFormWIF extends React.PureComponent {
 
     return (
       <form className={styles.loginForm} onSubmit={this.handleLogin}>
-        <Input
+        <LabeledInput
           id="encryptedWIF"
           type="password"
           label="Encrypted WIF"
@@ -41,7 +41,7 @@ export default class LoginFormWIF extends React.PureComponent {
           disabled={disabled}
           onChange={this.handleChangeEncryptedWIF}
         />
-        <Input
+        <LabeledInput
           id="passphrase"
           type="password"
           label="Passphrase"

--- a/src/renderer/login/components/LoginFormWIF/LoginFormWIF.js
+++ b/src/renderer/login/components/LoginFormWIF/LoginFormWIF.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { bool, string, func } from 'prop-types';
 import { noop } from 'lodash';
 
-import Input from 'shared/components/Forms/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
 
 import styles from './LoginFormWIF.scss';
@@ -27,7 +27,7 @@ export default class LoginFormWIF extends React.PureComponent {
 
     return (
       <form className={styles.loginForm} onSubmit={this.handleLogin}>
-        <Input
+        <LabeledInput
           id="wif"
           type="password"
           label="WIF"

--- a/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
+++ b/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
@@ -6,8 +6,8 @@ import { wallet } from '@cityofzion/neon-js';
 
 import Button from 'shared/components/Forms/Button';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
-import Select from 'shared/components/Forms/Select';
-import Input from 'shared/components/Forms/Input/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
+import LabeledSelect from 'shared/components/Forms/LabeledSelect';
 
 import styles from './LoginFormWalletFile.scss';
 
@@ -62,7 +62,7 @@ export default class LoginFormWalletFile extends React.PureComponent {
     }
 
     return (
-      <Select
+      <LabeledSelect
         id="account"
         className={styles.accounts}
         value={encryptedWIF}
@@ -73,7 +73,7 @@ export default class LoginFormWalletFile extends React.PureComponent {
         {map(this.props.accounts, (account, index) => (
           <option value={account.encrypted} key={`account${index}`}>{account.label}</option>
         ))}
-      </Select>
+      </LabeledSelect>
     );
   }
 
@@ -85,7 +85,7 @@ export default class LoginFormWalletFile extends React.PureComponent {
     }
 
     return (
-      <Input
+      <LabeledInput
         id="passphrase"
         type="password"
         label="Passphrase"

--- a/src/renderer/register/components/AccountDetails/SaveAccount/SaveAccount.js
+++ b/src/renderer/register/components/AccountDetails/SaveAccount/SaveAccount.js
@@ -6,7 +6,7 @@ import { promisify } from 'es6-promisify';
 import { noop, isEmpty } from 'lodash';
 import { wallet } from '@cityofzion/neon-js';
 
-import Input from 'shared/components/Forms/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
 
 import accountShape from '../../../shapes/accountShape';
@@ -35,7 +35,7 @@ export default class SaveAccount extends React.PureComponent {
   render() {
     return (
       <div className={styles.saveAccount}>
-        <Input
+        <LabeledInput
           className={styles.label}
           id="label"
           label="Account Label"

--- a/src/renderer/register/components/RegisterForm/RegisterForm.js
+++ b/src/renderer/register/components/RegisterForm/RegisterForm.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { bool, string, func } from 'prop-types';
 import { noop } from 'lodash';
 
-import Input from 'shared/components/Forms/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
 
 import styles from './RegisterForm.scss';
@@ -32,7 +32,7 @@ export default class RegisterForm extends React.PureComponent {
 
     return (
       <form className={styles.registerForm} onSubmit={this.handleRegister}>
-        <Input
+        <LabeledInput
           id="passphrase"
           type="password"
           label="Passphrase"
@@ -41,7 +41,7 @@ export default class RegisterForm extends React.PureComponent {
           disabled={loading}
           onChange={this.handleChangePassphrase}
         />
-        <Input
+        <LabeledInput
           id="passphraseConfirmation"
           type="password"
           label="Confirm Passphrase"

--- a/src/renderer/settings/components/NetworkSettings/NetworkSettings.js
+++ b/src/renderer/settings/components/NetworkSettings/NetworkSettings.js
@@ -3,10 +3,10 @@ import { func, string, object, arrayOf } from 'prop-types';
 import { settings } from '@cityofzion/neon-js';
 import { noop, map } from 'lodash';
 
-import Input from 'shared/components/Forms/Input';
+import LabeledInput from 'shared/components/Forms/LabeledInput';
+import LabeledSelect from 'shared/components/Forms/LabeledSelect';
 import Button from 'shared/components/Forms/Button';
 import PrimaryButton from 'shared/components/Forms/PrimaryButton';
-import Select from 'shared/components/Forms/Select';
 import NetworkIcon from 'shared/images/settings/network.svg';
 
 import SectionTitle from '../SectionTitle';
@@ -39,7 +39,7 @@ export default class NetworkSettings extends React.PureComponent {
         </SectionTitle>
 
         <SectionContent>
-          <Select
+          <LabeledSelect
             className={styles.input}
             labelClass={styles.label}
             id="network"
@@ -48,9 +48,9 @@ export default class NetworkSettings extends React.PureComponent {
             onChange={this.handleChangeSelectedNetwork}
           >
             {map(settings.networks, this.renderNetworkOption)}
-          </Select>
+          </LabeledSelect>
 
-          <Input
+          <LabeledInput
             className={styles.input}
             labelClass={styles.label}
             id="neoscan"
@@ -94,14 +94,14 @@ export default class NetworkSettings extends React.PureComponent {
   handleAddNewNetwork = () => {
     this.props.confirm((
       <div>
-        <Input
+        <LabeledInput
           id="networkName"
           type="text"
           label="Network name"
           placeholder="Network name"
           onChange={this.handleChangeNetworkName}
         />
-        <Input
+        <LabeledInput
           id="networkURL"
           type="text"
           label="Network URL"

--- a/src/renderer/shared/components/Forms/Input/Input.js
+++ b/src/renderer/shared/components/Forms/Input/Input.js
@@ -1,46 +1,26 @@
 import React from 'react';
 import classNames from 'classnames';
 import { string } from 'prop-types';
-import { omit } from 'lodash';
 
 import styles from './Input.scss';
 
 export default class Input extends React.PureComponent {
   static propTypes = {
-    className: string,
-    id: string.isRequired,
-    label: string,
-    labelClass: string
+    className: string
   };
 
   static defaultProps = {
-    className: null,
-    label: null,
-    labelClass: null
+    className: null
   };
 
   render() {
-    const { id, className } = this.props;
+    const { className, ...passDownProps } = this.props;
 
     return (
-      <label htmlFor={id} className={classNames(styles.input, className)}>
-        {this.renderLabel()}
-        <input id={id} {...omit(this.props, 'className', 'label', 'labelClass')} />
-      </label>
-    );
-  }
-
-  renderLabel = () => {
-    const { label, labelClass } = this.props;
-
-    if (!label) {
-      return null;
-    }
-
-    return (
-      <span className={classNames(styles.label, labelClass)}>
-        {label}
-      </span>
+      <input
+        {...passDownProps}
+        className={classNames(styles.input, className)}
+      />
     );
   }
 }

--- a/src/renderer/shared/components/Forms/Input/Input.scss
+++ b/src/renderer/shared/components/Forms/Input/Input.scss
@@ -1,40 +1,24 @@
 .input {
   display: block;
-  margin: 0 0 16px;
+  width: 100%;
+  padding: 6px 12px;
+  color: $primary-text-color;
+  background: #f9fafb;
+  border: 1px solid $light-text-color;
+  border-radius: 4px;
+  line-height: 17px;
+  font-size: 14px;
+  font-weight: 500;
+  -webkit-font-smoothing: antialiased;
 
-  .label {
-    display: block;
-    height: 17px;
-    line-height: 17px;
-    margin-bottom: 6px;
-    color: $primary-text-color;
-    font-size: 14px;
-    font-weight: 500;
-    -webkit-font-smoothing: antialiased;
+  &::placeholder {
+    color: $light-text-color;
   }
 
-  input {
-    display: block;
-    width: 100%;
-    padding: 6px 12px;
-    color: $primary-text-color;
-    background: #f9fafb;
-    border: 1px solid $light-text-color;
-    border-radius: 4px;
-    line-height: 17px;
-    font-size: 14px;
-    font-weight: 500;
-    -webkit-font-smoothing: antialiased;
-
-    &::placeholder {
-      color: $light-text-color;
-    }
-
-    &:focus {
-      // border-image: linear-gradient(to right, #b9d532, #5bba47)
-      border: 2px solid #b9d532;
-      padding: 5px 11px;
-      outline: none;
-    }
+  &:focus {
+    // border-image: linear-gradient(to right, #b9d532, #5bba47)
+    border: 2px solid #b9d532;
+    padding: 5px 11px;
+    outline: none;
   }
 }

--- a/src/renderer/shared/components/Forms/Label/Label.js
+++ b/src/renderer/shared/components/Forms/Label/Label.js
@@ -1,0 +1,48 @@
+/* eslint-disable jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */
+
+import React from 'react';
+import classNames from 'classnames';
+import { string, node } from 'prop-types';
+
+import styles from './Label.scss';
+
+export default class Label extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    label: node.isRequired,
+    htmlFor: string.isRequired,
+    children: node
+  };
+
+  static defaultProps = {
+    className: null,
+    children: null
+  };
+
+  render() {
+    const { className, label, children, htmlFor, ...passDownProps } = this.props;
+
+    return (
+      <label {...passDownProps} htmlFor={htmlFor} className={classNames(styles.wrapper, className)}>
+        <span className={styles.label}>
+          {label}
+        </span>
+        {children}
+      </label>
+    );
+  }
+
+  renderLabel = () => {
+    const { label, labelClass } = this.props;
+
+    if (!label) {
+      return null;
+    }
+
+    return (
+      <span className={classNames(styles.label, labelClass)}>
+        {label}
+      </span>
+    );
+  }
+}

--- a/src/renderer/shared/components/Forms/Label/Label.scss
+++ b/src/renderer/shared/components/Forms/Label/Label.scss
@@ -1,0 +1,14 @@
+.wrapper {
+  display: block;
+
+  .label {
+    display: block;
+    height: 17px;
+    line-height: 17px;
+    margin-bottom: 6px;
+    color: $primary-text-color;
+    font-size: 14px;
+    font-weight: 500;
+    -webkit-font-smoothing: antialiased;
+  }
+}

--- a/src/renderer/shared/components/Forms/Label/index.js
+++ b/src/renderer/shared/components/Forms/Label/index.js
@@ -1,0 +1,1 @@
+export { default } from './Label';

--- a/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.js
+++ b/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+import { string, node } from 'prop-types';
+
+import Label from '../Label';
+import Input from '../Input';
+import styles from './LabeledInput.scss';
+
+export default function LabeledInput(props) {
+  const { id, label, labelClass, ...passDownProps } = props;
+
+  return (
+    <Label htmlFor={id} label={label} className={classNames(styles.labeledInput, labelClass)}>
+      <Input id={id} {...passDownProps} />
+    </Label>
+  );
+}
+
+LabeledInput.propTypes = {
+  id: string.isRequired,
+  label: node.isRequired,
+  labelClass: string
+};
+
+LabeledInput.defaultProps = {
+  labelClass: null
+};

--- a/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.scss
+++ b/src/renderer/shared/components/Forms/LabeledInput/LabeledInput.scss
@@ -1,0 +1,3 @@
+.labeledInput {
+  margin: 0 0 16px;
+}

--- a/src/renderer/shared/components/Forms/LabeledInput/index.js
+++ b/src/renderer/shared/components/Forms/LabeledInput/index.js
@@ -1,0 +1,1 @@
+export { default } from './LabeledInput';

--- a/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.js
+++ b/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+import { string, node } from 'prop-types';
+
+import Label from '../Label';
+import Select from '../Select';
+import styles from './LabeledSelect.scss';
+
+export default function LabeledSelect(props) {
+  const { id, label, labelClass, ...passDownProps } = props;
+
+  return (
+    <Label htmlFor={id} label={label} className={classNames(styles.labeledSelect, labelClass)}>
+      <Select id={id} {...passDownProps} />
+    </Label>
+  );
+}
+
+LabeledSelect.propTypes = {
+  id: string.isRequired,
+  label: node.isRequired,
+  labelClass: string
+};
+
+LabeledSelect.defaultProps = {
+  labelClass: null
+};

--- a/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.scss
+++ b/src/renderer/shared/components/Forms/LabeledSelect/LabeledSelect.scss
@@ -1,0 +1,3 @@
+.labeledSelect {
+  margin: 0 0 16px;
+}

--- a/src/renderer/shared/components/Forms/LabeledSelect/index.js
+++ b/src/renderer/shared/components/Forms/LabeledSelect/index.js
@@ -1,0 +1,1 @@
+export { default } from './LabeledSelect';

--- a/src/renderer/shared/components/Forms/Select/Select.js
+++ b/src/renderer/shared/components/Forms/Select/Select.js
@@ -1,46 +1,26 @@
 import React from 'react';
 import classNames from 'classnames';
 import { string } from 'prop-types';
-import { omit } from 'lodash';
 
 import styles from './Select.scss';
 
 export default class Select extends React.PureComponent {
   static propTypes = {
-    className: string,
-    id: string.isRequired,
-    label: string,
-    labelClass: string
+    className: string
   };
 
   static defaultProps = {
-    className: null,
-    label: null,
-    labelClass: null
+    className: null
   };
 
   render() {
-    const { id, className } = this.props;
-
-    return ( // eslint-disable-next-line jsx-a11y/label-has-for
-      <label htmlFor={id} className={classNames(styles.select, className)}>
-        {this.renderLabel()}
-        <select id={id} {...omit(this.props, 'className', 'label', 'labelClass')} />
-      </label>
-    );
-  }
-
-  renderLabel = () => {
-    const { label, labelClass } = this.props;
-
-    if (!label) {
-      return null;
-    }
+    const { className, ...passDownProps } = this.props;
 
     return (
-      <span className={classNames(styles.label, labelClass)}>
-        {label}
-      </span>
+      <select
+        {...passDownProps}
+        className={classNames(styles.select, className)}
+      />
     );
   }
 }

--- a/src/renderer/shared/components/Forms/Select/Select.scss
+++ b/src/renderer/shared/components/Forms/Select/Select.scss
@@ -1,40 +1,24 @@
 .select {
-  display: block;
-  margin: 0 0 16px;
+  width: 100%;
+  height: 31px;
+  padding: 6px 12px;
+  color: $primary-text-color;
+  background: #f9fafb;
+  border: 1px solid $light-text-color;
+  border-radius: 4px;
+  line-height: 17px;
+  font-size: 14px;
+  font-weight: 500;
+  -webkit-font-smoothing: antialiased;
 
-  .label {
-    display: block;
-    height: 17px;
-    line-height: 17px;
-    margin-bottom: 6px;
-    color: $primary-text-color;
-    font-size: 14px;
-    font-weight: 500;
-    -webkit-font-smoothing: antialiased;
+  &::placeholder {
+    color: $light-text-color;
   }
 
-  select {
-    width: 100%;
-    height: 31px;
-    padding: 6px 12px;
-    color: $primary-text-color;
-    background: #f9fafb;
-    border: 1px solid $light-text-color;
-    border-radius: 4px;
-    line-height: 17px;
-    font-size: 14px;
-    font-weight: 500;
-    -webkit-font-smoothing: antialiased;
-
-    &::placeholder {
-      color: $light-text-color;
-    }
-
-    &:focus {
-      // border-image: linear-gradient(to right, #b9d532, #5bba47)
-      border: 2px solid #b9d532;
-      padding: 5px 11px;
-      outline: none;
-    }
+  &:focus {
+    // border-image: linear-gradient(to right, #b9d532, #5bba47)
+    border: 2px solid #b9d532;
+    padding: 5px 11px;
+    outline: none;
   }
 }


### PR DESCRIPTION
## Description
This breaks the existing `Input` and `Select` components apart so that the labels are no longer embedded within them.  Two new components -- `LabeledInput` and `LabeledSelect` -- provide the functionality that these were providing before.

## Motivation and Context
While working on the new select component (from the new designs), I found that I needed to reuse the `Input` component with custom styling, but having it wrapped in a label made that difficult.  This lays the groundwork for that use case without breaking any existing implementation.

## How Has This Been Tested?
Smoke tested forms throughout the app & added some basic component tests.

## Screenshots (if appropriate)
N/A

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A