### PR TITLE
chore(tests): fixed missing prop warnings

### DIFF
--- a/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledInput/index.test.js
@@ -10,7 +10,7 @@ const mountContainer = (props = {}) => {
 
 describe('<LabeledInput />', () => {
   it('forwards the ref to the component', () => {
-    const wrapper = mountContainer({ ref: React.createRef() });
+    const wrapper = mountContainer({ id: 'foo', label: 'Foo', ref: React.createRef() });
     expect(wrapper).toForwardRefTo(LabeledInput);
   });
 });

--- a/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
+++ b/__tests__/renderer/shared/components/Forms/LabeledSelect/index.test.js
@@ -10,7 +10,7 @@ const mountContainer = (props = {}) => {
 
 describe('<LabeledSelect />', () => {
   it('forwards the ref to the component', () => {
-    const wrapper = mountContainer({ ref: React.createRef() });
+    const wrapper = mountContainer({ id: 'foo', label: 'Foo', ref: React.createRef() });
     expect(wrapper).toForwardRefTo(LabeledSelect);
   });
 });


### PR DESCRIPTION
## Description
This fixes some test warnings due to missing props.

## Motivation and Context
Unnecessary warnings make it hard to scan & parse test output.

## How Has This Been Tested?
Running `yarn test`.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A