### PR TITLE
feat(browser): perform search for non-URI queries

### DIFF
--- a/__tests__/renderer/browser/util/parseURL.test.js
+++ b/__tests__/renderer/browser/util/parseURL.test.js
@@ -48,4 +48,8 @@ describe('parseURL', () => {
   it('handles .com TLD without protocol, with query string', () => {
     expect(parseURL('example.com?foo=bar')).toEqual(new URL('http://example.com?foo=bar'));
   });
+
+  it('handles search queries', () => {
+    expect(parseURL('example.com lol jk')).toEqual(new URL('https://www.google.com/search?q=example.com+lol+jk'));
+  });
 });

--- a/__tests__/renderer/browser/util/parseURL.test.js
+++ b/__tests__/renderer/browser/util/parseURL.test.js
@@ -52,6 +52,6 @@ describe('parseURL', () => {
   });
 
   it('handles search queries', () => {
-    expect(parseURL('example.com lol jk')).toEqual(new URL('https://www.google.com/search?q=example.com+lol+jk'));
+    expect(parseURL('example.com lol jk')).toEqual(new URL('https://duckduckgo.com/?q=example.com+lol+jk'));
   });
 });

--- a/__tests__/renderer/browser/util/parseURL.test.js
+++ b/__tests__/renderer/browser/util/parseURL.test.js
@@ -1,3 +1,5 @@
+import { URL } from 'whatwg-url';
+
 import parseURL from 'browser/util/parseURL';
 
 describe('parseURL', () => {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "spunky": "1.3.1",
     "switch-tree": "0.2.2",
     "uuid": "3.3.2",
-    "what-input": "5.1.1"
+    "what-input": "5.1.1",
+    "whatwg-url": "7.0.0"
   },
   "scripts": {
     "start": "yarn build:main && run-p -l -n -r start:renderer start:electron",

--- a/src/renderer/browser/util/parseURL.js
+++ b/src/renderer/browser/util/parseURL.js
@@ -16,5 +16,10 @@ export default function parseURL(query) {
   }
 
   const tld = getTLD(trimmedQuery);
-  return new URL(`${tld}//${trimmedQuery}`);
+
+  try {
+    return new URL(`${tld}//${trimmedQuery}`);
+  } catch (err) {
+    return new URL(`https://www.google.com/search?q=${encodeURIComponent(trimmedQuery)}`);
+  }
 }

--- a/src/renderer/browser/util/parseURL.js
+++ b/src/renderer/browser/util/parseURL.js
@@ -22,6 +22,6 @@ export default function parseURL(query) {
   try {
     return new URL(url);
   } catch (err) {
-    return new URL(`https://www.google.com/search?q=${encodeURIComponent(trimmedQuery)}`);
+    return new URL(`https://duckduckgo.com/?q=${encodeURIComponent(trimmedQuery)}`);
   }
 }

--- a/src/renderer/browser/util/parseURL.js
+++ b/src/renderer/browser/util/parseURL.js
@@ -1,3 +1,4 @@
+import { URL } from 'whatwg-url';
 import { filter, isEmpty, trim } from 'lodash';
 
 import { HTTP, CUSTOM_PROTOCOLS } from '../values/protocols';
@@ -16,9 +17,10 @@ export default function parseURL(query) {
   }
 
   const tld = getTLD(trimmedQuery);
+  const url = `${tld}//${trimmedQuery}`;
 
   try {
-    return new URL(`${tld}//${trimmedQuery}`);
+    return new URL(url);
   } catch (err) {
     return new URL(`https://www.google.com/search?q=${encodeURIComponent(trimmedQuery)}`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10395,6 +10395,14 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
+whatwg-url@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
 whatwg-url@^6.4.0, whatwg-url@^6.4.1:
   version "6.5.0"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"


### PR DESCRIPTION
## Description
This makes non-URI entries in the address bar behave as Google searches.  In the future, we can allow customizing the search engine.

## Motivation and Context
When the user enters something into the address bar that is not a valid URI, we should treat it as a search query.

## How Has This Been Tested?
Adding tests and smoke testing.

## Screenshots (if appropriate)
![search-query](https://user-images.githubusercontent.com/169093/44961710-1fd62980-aedb-11e8-9ff1-7f774a0642a7.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes part of #371.