### PR TITLE
chore(login): select wallet file dialog context

### DIFF
--- a/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
+++ b/src/renderer/login/components/LoginFormWalletFile/LoginFormWalletFile.js
@@ -112,7 +112,7 @@ export default class LoginFormWalletFile extends React.PureComponent {
   };
 
   handleLoadWallet = () => {
-    const filenames = remote.dialog.showOpenDialog({
+    const filenames = remote.dialog.showOpenDialog(remote.getCurrentWindow(), {
       title: 'Select Wallet file',
       filters: [{ name: 'Wallet file', extensions: ['json'] }]
     });


### PR DESCRIPTION
## Description
Similar to #497, this is a very minor fix such that when opening a wallet file for login via NEP2, the dialog is attached to the window.

## Motivation and Context
I noticed that the "Select Wallet File" dialogs was not attached to the window, but was instead free-floating.

## How Has This Been Tested?
Selecting a wallet file to use to login.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A