### PR TITLE
chore(send): prevent reload

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,9 +26,14 @@ let splashWindow;
 const isMac = process.platform === 'darwin';
 
 function getWindowPath(productionPath, filename) {
-  return isDev
+  const windowPath = isDev
     ? `http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}/${filename}`
     : url.format({ pathname: path.join(productionPath, filename), protocol: 'file:', slashes: true });
+
+  // There is a peculiar bug that is causing the window location to redirect to the current URL, but
+  // with an empty query string appended. By loading that URL initially instead, no redirect occurs.
+  // REF: https://github.com/nos/client/issues/340#issuecomment-414095942
+  return windowPath.includes('?') ? windowPath : `${windowPath}?`;
 }
 
 function createWindow() {


### PR DESCRIPTION
## Description
This prevents the app from seemingly reloading the first time the confirmation modal is displayed.

## Motivation and Context
https://github.com/nos/client/issues/340#issuecomment-414095942

## How Has This Been Tested?
Sending an asset through the account screen.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #340