### PR TITLE
feat(api): added getLastBlock api function

### DIFF
--- a/__tests__/renderer/browser/components/RequestsProcessor/GetAddress/index.test.js
+++ b/__tests__/renderer/browser/components/RequestsProcessor/GetAddress/index.test.js
@@ -28,7 +28,7 @@ describe('<GetBalance />', () => {
   beforeEach(() => {
     onResolve = jest.fn();
     onReject = jest.fn();
-    mountContainer({ ...defaultProps, onResolve });
+    mountContainer({ ...defaultProps, onResolve, onReject });
   });
 
   it('resolves with the currently authenticated address', () => {

--- a/__tests__/renderer/browser/components/RequestsProcessor/GetLastBlock/GetLastBlock.test.js
+++ b/__tests__/renderer/browser/components/RequestsProcessor/GetLastBlock/GetLastBlock.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+
+import GetLastBlock from 'browser/components/RequestsProcessor/GetLastBlock/GetLastBlock';
+import block from 'fixtures/block.json';
+
+describe('<GetLastBlock />', () => {
+  const defaultProps = { block, onResolve: noop, onReject: noop };
+
+  it('renders nothing', () => {
+    const wrapper = mount(<GetLastBlock {...defaultProps} />);
+    expect(wrapper.children()).toHaveLength(0);
+  });
+
+  describe('when given a block', () => {
+    it('calls onResolve with block', () => {
+      const onResolve = jest.fn();
+      mount(<GetLastBlock {...defaultProps} onResolve={onResolve} />);
+      expect(onResolve).toHaveBeenCalledWith(block);
+    });
+  });
+
+  describe('when not given a block', () => {
+    it('calls onReject with error message', () => {
+      const onReject = jest.fn();
+      mount(<GetLastBlock {...defaultProps} block={null} onReject={onReject} />);
+      expect(onReject).toHaveBeenCalledWith('Unavailable');
+    });
+  });
+});

--- a/__tests__/renderer/browser/components/RequestsProcessor/GetLastBlock/index.test.js
+++ b/__tests__/renderer/browser/components/RequestsProcessor/GetLastBlock/index.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+
+import { provideStore, createStore, spunkyKey, mockSpunkyLoaded } from 'testHelpers';
+import block from 'fixtures/block.json';
+
+import makeGetLastBlock from 'browser/components/RequestsProcessor/GetLastBlock';
+
+const getStore = () => createStore({
+  [spunkyKey]: {
+    block: mockSpunkyLoaded(block)
+  }
+});
+
+describe('<GetLastBlock />', () => {
+  let onResolve;
+  let onReject;
+
+  const GetLastBlock = makeGetLastBlock();
+  const defaultProps = { args: [], onResolve: noop, onReject: noop };
+
+  const mountContainer = (props) => {
+    return mount(provideStore(<GetLastBlock {...props} />, getStore()));
+  };
+
+  beforeEach(() => {
+    onResolve = jest.fn();
+    onReject = jest.fn();
+    mountContainer({ ...defaultProps, onResolve, onReject });
+  });
+
+  it('resolves with the last block', () => {
+    expect(onResolve).toHaveBeenCalledWith(block);
+    expect(onReject).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.test.js
+++ b/__tests__/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.test.js
@@ -12,6 +12,18 @@ describe('<LastBlock />', () => {
     expect(wrapper.find('.network').text()).toContain(network);
   });
 
+  describe("when there's no error and no block", () => {
+    it('renders connecting icon', () => {
+      const wrapper = mount(<LastBlock currentNetwork={network} />);
+      expect(wrapper.find('.icon.connecting').exists()).toBe(true);
+    });
+
+    it('renders "Connecting..."', () => {
+      const wrapper = mount(<LastBlock currentNetwork={network} />);
+      expect(wrapper.find('.block').text()).toContain('Connecting...');
+    });
+  });
+
   describe("when there's no error", () => {
     it('renders connected icon', () => {
       const wrapper = mount(<LastBlock currentNetwork={network} block={block} />);

--- a/src/renderer/browser/components/RequestsProcessor/GetLastBlock/GetLastBlock.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetLastBlock/GetLastBlock.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { func } from 'prop-types';
+
+import blockShape from 'shared/shapes/blockShape';
+
+export default class GetLastBlock extends React.PureComponent {
+  static propTypes = {
+    block: blockShape,
+    onResolve: func.isRequired,
+    onReject: func.isRequired
+  };
+
+  static defaultProps = {
+    block: null
+  };
+
+  componentDidMount() {
+    const { block, onResolve, onReject } = this.props;
+
+    if (block) {
+      onResolve(block);
+    } else {
+      onReject('Unavailable');
+    }
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/renderer/browser/components/RequestsProcessor/GetLastBlock/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/GetLastBlock/index.js
@@ -1,0 +1,11 @@
+import { withData } from 'spunky';
+
+import blockActions from 'shared/actions/blockActions';
+
+import GetLastBlock from './GetLastBlock';
+
+const mapBlockDataToProps = (block) => ({ block });
+
+export default function makeGetLastBlock() {
+  return withData(blockActions, mapBlockDataToProps)(GetLastBlock);
+}

--- a/src/renderer/browser/components/RequestsProcessor/mappings.js
+++ b/src/renderer/browser/components/RequestsProcessor/mappings.js
@@ -2,6 +2,7 @@ import GetAddress from './GetAddress';
 import GetBalance from './GetBalance';
 import Invoke from './Invoke';
 import TestInvoke from './TestInvoke';
+import GetLastBlock from './GetLastBlock';
 import GetStorage from './GetStorage';
 import Send from './Send';
 import ClaimGas from './ClaimGas';
@@ -17,6 +18,7 @@ const COMPONENT_MAP = {
   getBalance: GetBalance,
   getStorage: GetStorage,
   testInvoke: TestInvoke,
+  getLastBlock: GetLastBlock,
   invoke: Invoke,
   send: Send,
   claimGas: ClaimGas

--- a/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.js
+++ b/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.js
@@ -24,7 +24,7 @@ export default class LastBlock extends React.PureComponent {
     return (
       <div className={styles.lastBlock}>
         <div className={styles.network}>
-          <span className={this.getIconClassName()} />
+          <span className={classNames(styles.icon, this.getIconClassName())} />
           <span className={styles.name}>{currentNetwork}</span>
         </div>
         {this.renderDetails()}
@@ -33,7 +33,11 @@ export default class LastBlock extends React.PureComponent {
   }
 
   renderDetails = () => {
-    const { block } = this.props;
+    const { block, error } = this.props;
+
+    if (!block && !error) {
+      return <div className={styles.block}>Connecting...</div>;
+    }
 
     if (!block) {
       return <div className={styles.block}>Disconnected</div>;
@@ -57,7 +61,13 @@ export default class LastBlock extends React.PureComponent {
   }
 
   getIconClassName = () => {
-    return classNames(styles.icon, this.props.error ? styles.disconnected : styles.connected);
+    if (this.props.error) {
+      return styles.disconnected;
+    } else if (this.props.block) {
+      return styles.connected;
+    } else {
+      return styles.connecting;
+    }
   }
 
   getTimestamp = (block) => {

--- a/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.scss
@@ -20,6 +20,10 @@
       &.disconnected {
         background-color: #ff6a4a;
       }
+
+      &.connecting {
+        background-color: $light-text-color;
+      }
     }
 
     .name {

--- a/src/renderer/settings/components/NetworkSettings/index.js
+++ b/src/renderer/settings/components/NetworkSettings/index.js
@@ -2,6 +2,7 @@ import { compose, withState } from 'recompose';
 import { withActions, progressValues } from 'spunky';
 
 import balancesActions from 'shared/actions/balancesActions';
+import blockActions from 'shared/actions/blockActions';
 import withNetworkData from 'shared/hocs/withNetworkData';
 import withAllNetworkData from 'shared/hocs/withAllNetworkData';
 import withProgressChange from 'shared/hocs/withProgressChange';
@@ -16,6 +17,11 @@ const { LOADED, FAILED } = progressValues;
 
 const mapBalancesActionsToProps = (actions) => ({
   resetAccountData: actions.reset
+});
+
+const mapBlockActionsToProps = (actions) => ({
+  resetBlockData: actions.reset,
+  getBlockData: actions.call
 });
 
 const mapCurrentNetworkActionsToProps = (actions) => ({
@@ -40,6 +46,7 @@ export default compose(
   withActions(setNetworks, mapNetworksActionsToProps),
   withActions(addNetwork, mapAddNetworksActionsToProps),
   withActions(clearNetworks, mapClearNetworksActionsToProps),
+  withActions(blockActions, mapBlockActionsToProps),
 
   // Get network settings data
   withAllNetworkData(),
@@ -47,8 +54,10 @@ export default compose(
 
   // Load balance data whenever the network is assigned or changed
   withActions(balancesActions, mapBalancesActionsToProps),
-  withProgressChange(currentNetworkActions, [LOADED, FAILED], (state, { resetAccountData }) => {
-    resetAccountData();
+  withProgressChange(currentNetworkActions, [LOADED, FAILED], (state, props) => {
+    props.resetAccountData();
+    props.resetBlockData();
+    props.getBlockData({ net: props.currentNetwork });
   }),
 
   // Dialog

--- a/static/preloadRenderer.js
+++ b/static/preloadRenderer.js
@@ -33,6 +33,7 @@ const V1 = {
   getBalance: createDelegate('getBalance'),
   getStorage: createDelegate('getStorage'),
   testInvoke: createDelegate('testInvoke'),
+  getLastBlock: createDelegate('getLastBlock'),
 
   // Permissions required
   invoke: createDelegate('invoke'),


### PR DESCRIPTION
**NOTE**: Do not merge until #521 has been merged.  This builds off that PR.  This PR will need to be updated to set the target branch to `develop` before merging.

## Description
This adds a `getLastBlock` API function for dApps.

## Motivation and Context
dApps may want to request the latest block data.  An example is what @jeroenptrs is working on.

## How Has This Been Tested?
Opening the inspector on a webview, and calling:

```js
window.NOS.V1.getLastBlock().then(function(block) { console.log(block) })
```

## Screenshots (if appropriate)
<img width="1254" alt="screen shot 2018-09-11 at 7 47 25 pm" src="https://user-images.githubusercontent.com/169093/45395396-8f46ca00-b5fb-11e8-97e9-1d2fc2e8be84.png">

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [x] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A