### PR TITLE
chore(nav): add exchange sidebar link

### DIFF
--- a/src/renderer/browser/values/browserValues.js
+++ b/src/renderer/browser/values/browserValues.js
@@ -3,4 +3,5 @@ export const EXTERNAL = 1;
 
 export const DAPPS = 'DApps';
 export const ACCOUNT = 'Account';
+export const EXCHANGE = 'Exchange';
 export const SETTINGS = 'Settings';

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -6,9 +6,10 @@ import { NavLink } from 'react-router-dom';
 import { string } from 'prop-types';
 import { noop } from 'lodash';
 
-import { DAPPS, ACCOUNT, SETTINGS } from 'browser/values/browserValues';
+import { DAPPS, ACCOUNT, EXCHANGE, SETTINGS } from 'browser/values/browserValues';
 import DAppsIcon from 'shared/images/icons/dapps.svg';
 import AccountIcon from 'shared/images/icons/account.svg';
+import ExchangeIcon from 'shared/images/icons/exchange.svg';
 import SettingsIcon from 'shared/images/icons/settings.svg';
 import LogoutIcon from 'shared/images/icons/logout.svg';
 import Tooltip from 'shared/components/Tooltip';
@@ -27,6 +28,15 @@ export default function Navigation(props) {
             <div>
               <TabLink id="dapps" target={DAPPS} disabled>
                 <DAppsIcon aria-label="dapps" />
+              </TabLink>
+            </div>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip overlay="Exchange">
+            <div>
+              <TabLink id="exchange" target={EXCHANGE} disabled>
+                <ExchangeIcon aria-label="exchange" />
               </TabLink>
             </div>
           </Tooltip>

--- a/src/renderer/shared/images/icons/exchange.svg
+++ b/src/renderer/shared/images/icons/exchange.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.3412 24.6575L13.3618 27.8011L24.7941 15.9031L29 20.3201V5.27856L10.3412 24.6575Z" fill="currentColor"/>
+<path d="M22.1176 8.10381L19.0971 5L7.66471 16.8979L3 12.9585V28L22.1176 8.10381Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Description
Adds "Exchange" sidebar link.

## Motivation and Context
We want users to know that exchange functionality will be coming in the future.

## How Has This Been Tested?
Logged in, saw the icon, hovered the mouse, tried clicking.

## Screenshots (if appropriate)
<img width="172" alt="screen shot 2018-09-11 at 10 26 10 pm" src="https://user-images.githubusercontent.com/169093/45400481-e9528a00-b611-11e8-9981-2701e42562b3.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A