### PR TITLE
feat(api): events api for blocks

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/index.js
@@ -1,12 +1,17 @@
 import { compose } from 'recompose';
 import { connect } from 'react-redux';
-import { withActions } from 'spunky';
+import { withActions, withData, progressValues } from 'spunky';
+import { isEqual } from 'lodash';
 
 import blockActions from 'shared/actions/blockActions';
 import withAuthState from 'login/hocs/withAuthState';
 import withNetworkData from 'shared/hocs/withNetworkData';
+import withProgressChange from 'shared/hocs/withProgressChange';
+import notifyWebviews from 'shared/util/notifyWebviews';
 
 import AuthenticatedLayout from './AuthenticatedLayout';
+
+const { LOADED } = progressValues;
 
 const mapStateToProps = (state) => {
   const { tabs, activeSessionId } = state.browser;
@@ -17,9 +22,19 @@ const mapBlockActionsToProps = (actions, props) => ({
   getLastBlock: () => actions.call({ net: props.currentNetwork })
 });
 
+const mapBlockDataToProps = (block) => ({ block });
+
 export default compose(
   connect(mapStateToProps),
   withAuthState(),
   withNetworkData('currentNetwork'),
   withActions(blockActions, mapBlockActionsToProps),
+
+  // Whenever a new block is received, notify all dApps.
+  withData(blockActions, mapBlockDataToProps),
+  withProgressChange(blockActions, LOADED, (state, props, prevProps) => {
+    if (!isEqual(props.block, prevProps.block)) {
+      notifyWebviews('event', 'block', props.block);
+    }
+  })
 )(AuthenticatedLayout);

--- a/src/renderer/shared/hocs/withProgressChange.js
+++ b/src/renderer/shared/hocs/withProgressChange.js
@@ -23,7 +23,11 @@ export default function withProgressChange(actions, progress, callback) {
       componentWillReceiveProps(nextProps) {
         if (!progresses.includes(this.props[PROGRESS_PROP]) &&
             progresses.includes(nextProps[PROGRESS_PROP])) {
-          callback(this.getCallbackState(nextProps), this.getCallbackProps(nextProps));
+          callback(
+            this.getCallbackState(nextProps),
+            this.getCallbackProps(nextProps),
+            this.getCallbackProps(this.props)
+          );
         }
       }
 

--- a/src/renderer/shared/util/notifyWebviews.js
+++ b/src/renderer/shared/util/notifyWebviews.js
@@ -1,0 +1,12 @@
+import { remote } from 'electron';
+
+const TYPE_WEBVIEW = 'webview';
+
+function getAllWebviews() {
+  const webContents = remote.webContents.getAllWebContents();
+  return webContents.filter((wc) => wc.getType() === TYPE_WEBVIEW);
+}
+
+export default function notifyWebviews(...args) {
+  getAllWebviews().forEach((webview) => webview.send(...args));
+}

--- a/static/preloadRenderer.js
+++ b/static/preloadRenderer.js
@@ -17,8 +17,8 @@ function createDelegate(channel) {
     } catch (err) {
       reject(err);
     } finally {
-      ipcRenderer.removeListener(successChannel, resolve);
-      ipcRenderer.removeListener(failureChannel, reject);
+      ipcRenderer.removeAllListeners(successChannel);
+      ipcRenderer.removeAllListeners(failureChannel);
     }
   });
 }

--- a/static/preloadRenderer.js
+++ b/static/preloadRenderer.js
@@ -1,11 +1,12 @@
 const electron = require('electron');
-const { each, uniqueId, isEmpty, isUndefined } = require('lodash');
+const uuid = require('uuid/v1');
+const { each, isEmpty, isUndefined } = require('lodash');
 
 const { ipcRenderer } = electron;
 
 function createDelegate(channel) {
   return (...args) => new Promise((resolve, reject) => {
-    const id = uniqueId();
+    const id = uuid();
     const successChannel = `${channel}-success-${id}`;
     const failureChannel = `${channel}-failure-${id}`;
 
@@ -25,7 +26,7 @@ function createDelegate(channel) {
 const subscriptions = {};
 
 function on(eventName, callback) {
-  const id = uniqueId();
+  const id = uuid();
   subscriptions[eventName] = subscriptions[eventName] || {};
   subscriptions[eventName][id] = callback;
   return id;


### PR DESCRIPTION
## Description
Adds `on`, `off`, and `once` API functions to subscribe to events.  Added one event for new blocks being received.

## Motivation and Context
We want dApps to be aware of events pertaining to the NEO ecosystem.

## How Has This Been Tested?
Used the webview console to subscribe & unsubscribe.

## Screenshots (if appropriate)
<img width="1076" alt="screen shot 2018-09-13 at 7 56 47 pm" src="https://user-images.githubusercontent.com/169093/45523597-c2ba5d80-b78f-11e8-8190-625aa5cde58e.png">

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [x] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #54.