### PR TITLE
chore(block): fixed local block time

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.js
+++ b/src/renderer/root/components/AuthenticatedLayout/LastBlock/LastBlock.js
@@ -75,6 +75,6 @@ export default class LastBlock extends React.PureComponent {
       return null;
     }
 
-    return new Date(block.time).toLocaleTimeString();
+    return new Date(block.time * 1000).toLocaleTimeString();
   }
 }


### PR DESCRIPTION
## Description
The calculation for the block time in local time was incorrect.  We need to convert seconds to milliseconds first.

## Motivation and Context
Block time is not displaying correctly in the new sidenav tooltip.

## How Has This Been Tested?
Displaying the tooltip and comparing to my computer clock.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A