### PR TITLE
feat(block): open block in neoscan tab

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/ExplorerLink/ExplorerLink.js
+++ b/src/renderer/root/components/AuthenticatedLayout/ExplorerLink/ExplorerLink.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { EXTERNAL } from 'browser/values/browserValues';
+
+import TabLink from '../TabLink';
+
+export default function ExplorerLink(props) {
+  return <TabLink {...props} type={EXTERNAL} />;
+}

--- a/src/renderer/root/components/AuthenticatedLayout/ExplorerLink/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/ExplorerLink/index.js
@@ -1,0 +1,23 @@
+import { compose, withProps } from 'recompose';
+import { settings } from '@cityofzion/neon-js';
+import { URL } from 'whatwg-url';
+
+import withNetworkData from 'shared/hocs/withNetworkData';
+
+import ExplorerLink from './ExplorerLink';
+
+function getTarget(network) {
+  try {
+    const { protocol, host } = new URL(settings.networks[network].extra.neoscan);
+    return `${protocol}//${host}`;
+  } catch (err) {
+    return null;
+  }
+}
+
+export default compose(
+  withNetworkData('currentNetwork'),
+  withProps((props) => ({
+    target: getTarget(props.currentNetwork)
+  }))
+)(ExplorerLink);

--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.js
@@ -4,7 +4,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { NavLink } from 'react-router-dom';
 import { string } from 'prop-types';
-import { noop } from 'lodash';
 
 import { DAPPS, ACCOUNT, EXCHANGE, SETTINGS } from 'browser/values/browserValues';
 import DAppsIcon from 'shared/images/icons/dapps.svg';
@@ -15,75 +14,80 @@ import LogoutIcon from 'shared/images/icons/logout.svg';
 import Tooltip from 'shared/components/Tooltip';
 
 import TabLink from '../TabLink';
+import ExplorerLink from '../ExplorerLink';
 import LastBlock from '../LastBlock';
 import StatusIcon from '../StatusIcon';
 import styles from './Navigation.scss';
 
-export default function Navigation(props) {
-  return (
-    <nav className={classNames(styles.navigation, props.className)}>
-      <ul>
-        <li>
-          <Tooltip overlay="dApps">
-            <div>
-              <TabLink id="dapps" target={DAPPS} disabled>
-                <DAppsIcon aria-label="dapps" />
-              </TabLink>
-            </div>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip overlay="Exchange">
-            <div>
-              <TabLink id="exchange" target={EXCHANGE} disabled>
-                <ExchangeIcon aria-label="exchange" />
-              </TabLink>
-            </div>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip overlay="Account">
-            <div>
-              <TabLink id="account" target={ACCOUNT}>
-                <AccountIcon aria-label="account" />
-              </TabLink>
-            </div>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip overlay="Settings">
-            <div>
-              <TabLink id="settings" target={SETTINGS}>
-                <SettingsIcon aria-label="settings" />
-              </TabLink>
-            </div>
-          </Tooltip>
-        </li>
-      </ul>
-      <ul>
-        <li>
-          <Tooltip overlay={<LastBlock />}>
-            <div className={styles.link}>
-              <StatusIcon aria-label="status" />
-            </div>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip overlay="Logout">
-            <NavLink id="logout" exact to="/logout" draggable={false} className={styles.link}>
-              <LogoutIcon aria-label="logout" />
-            </NavLink>
-          </Tooltip>
-        </li>
-      </ul>
-    </nav>
-  );
+export default class Navigation extends React.PureComponent {
+  static propTypes = {
+    className: string
+  };
+
+  static defaultProps = {
+    className: null
+  };
+
+  render() {
+    return (
+      <nav className={classNames(styles.navigation, this.props.className)}>
+        <ul>
+          <li>
+            <Tooltip overlay="dApps">
+              <div>
+                <TabLink id="dapps" target={DAPPS} disabled>
+                  <DAppsIcon aria-label="dapps" />
+                </TabLink>
+              </div>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip overlay="Exchange">
+              <div>
+                <TabLink id="exchange" target={EXCHANGE} disabled>
+                  <ExchangeIcon aria-label="exchange" />
+                </TabLink>
+              </div>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip overlay="Account">
+              <div>
+                <TabLink id="account" target={ACCOUNT}>
+                  <AccountIcon aria-label="account" />
+                </TabLink>
+              </div>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip overlay="Settings">
+              <div>
+                <TabLink id="settings" target={SETTINGS}>
+                  <SettingsIcon aria-label="settings" />
+                </TabLink>
+              </div>
+            </Tooltip>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <Tooltip overlay={<LastBlock />}>
+              <div className={styles.link}>
+                <ExplorerLink id="status">
+                  <StatusIcon aria-label="status" />
+                </ExplorerLink>
+              </div>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip overlay="Logout">
+              <NavLink id="logout" exact to="/logout" draggable={false} className={styles.link}>
+                <LogoutIcon aria-label="logout" />
+              </NavLink>
+            </Tooltip>
+          </li>
+        </ul>
+      </nav>
+    );
+  }
 }
-
-Navigation.propTypes = {
-  className: string
-};
-
-Navigation.defaultProps = {
-  className: noop
-};

--- a/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
+++ b/src/renderer/root/components/AuthenticatedLayout/TabLink/TabLink.js
@@ -11,7 +11,7 @@ export default class TabLink extends React.PureComponent {
   static propTypes = {
     className: string,
     type: oneOf([INTERNAL, EXTERNAL]),
-    target: string.isRequired,
+    target: string,
     active: bool,
     disabled: bool,
     children: node,
@@ -21,6 +21,7 @@ export default class TabLink extends React.PureComponent {
   static defaultProps = {
     className: null,
     type: INTERNAL,
+    target: null,
     active: false,
     disabled: false,
     children: null,
@@ -48,7 +49,7 @@ export default class TabLink extends React.PureComponent {
   handleClick = () => {
     const { disabled, type, target } = this.props;
 
-    if (!disabled) {
+    if (target && !disabled) {
       this.props.openTab({ type, target });
     }
   }


### PR DESCRIPTION
## Description
This links the block side nav item to the block in neoscan.  Unfortunately, this probably won't work since neoscan is always at least one block behind the current block height.

## Motivation and Context
Dean requested as part of #527.

## How Has This Been Tested?
Clicking the link and navigating to neoscan.

## Screenshots (if appropriate)
![neoscan](https://user-images.githubusercontent.com/169093/45524673-43c82380-b795-11e8-9989-4ab89726f9e8.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #527.