### PR TITLE
chore(tooltip): remove mouse leave delay

### DIFF
--- a/src/renderer/shared/components/Tooltip/Tooltip.js
+++ b/src/renderer/shared/components/Tooltip/Tooltip.js
@@ -3,5 +3,5 @@ import ReactTooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap.css';
 
 export default function Tooltip(props) {
-  return <ReactTooltip {...props} />;
+  return <ReactTooltip mouseLeaveDelay={0} {...props} />;
 }


### PR DESCRIPTION
## Description
This PR sets the mouse-leave delay to 0s when hiding tooltips.

## Motivation and Context
This is an incremental improvement to the tooltip behavior.  By default, rc-tooltip has a 0.1s delay before hiding an element.  The impact is that multiple tooltips are visible at the same time, even if only momentarily.  Preferably, we only show a single tooltip at a time.

## How Has This Been Tested?
Hovering the mouse over side navigation icons quickly.

## Screenshots (if appropriate)
![tooltip-delay](https://user-images.githubusercontent.com/169093/45580740-42acfa00-b85a-11e8-9a77-f9fbd3c290d4.gif)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A