### PR TITLE
feat(balance): update balances on new blocks

### DIFF
--- a/__tests__/renderer/root/components/Layout/AuthenticatedLayout/AuthenticatedLayout.test.js
+++ b/__tests__/renderer/root/components/Layout/AuthenticatedLayout/AuthenticatedLayout.test.js
@@ -2,12 +2,16 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 
-import { provideState } from 'testHelpers';
+import { provideState, spunkyKey, mockSpunkyLoaded } from 'testHelpers';
 
 import AuthenticatedLayout from 'root/components/AuthenticatedLayout';
 import { EXTERNAL } from 'browser/values/browserValues';
 
 const initialState = {
+  [spunkyKey]: {
+    currentNetwork: mockSpunkyLoaded('MainNet'),
+    auth: mockSpunkyLoaded({ address: 'ALfnhLg7rUyL6Jr98bzzoxz5J7m64fbR4s' })
+  },
   browser: {
     currentNetwork: 'MainNet',
     activeSessionId: 'tab-1',

--- a/src/renderer/account/components/Account/index.js
+++ b/src/renderer/account/components/Account/index.js
@@ -1,5 +1,5 @@
 import { compose } from 'recompose';
-import { withData, withProgressComponents, progressValues } from 'spunky';
+import { withData, withProgressComponents, progressValues, alreadyLoadedStrategy } from 'spunky';
 import { pickBy, keys } from 'lodash';
 
 import Loading from 'shared/components/Loading';
@@ -40,10 +40,14 @@ export default compose(
   withProgressComponents(balancesActions, {
     [LOADING]: Loading,
     [FAILED]: Failed
+  }, {
+    strategy: alreadyLoadedStrategy
   }),
   withProgressComponents(pricesActions, {
     [LOADING]: Loading,
     [FAILED]: Failed
+  }, {
+    strategy: alreadyLoadedStrategy
   }),
 
   withData(balancesActions, mapBalancesDataToProps),

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
@@ -35,22 +35,18 @@ export default class AuthenticatedLayout extends React.PureComponent {
 
   componentDidMount() {
     this.props.getLastBlock();
-    this.pollInterval = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+    this.createPoll();
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.currentNetwork !== prevProps.currentNetwork) {
-      if (this.pollInterval) {
-        clearInterval(this.pollInterval);
-      }
-      this.pollInterval = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+      this.clearPoll();
+      this.createPoll();
     }
   }
 
   componentWillUnmount() {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-    }
+    this.clearPoll();
   }
 
   render() {
@@ -124,6 +120,16 @@ export default class AuthenticatedLayout extends React.PureComponent {
     this.setState((prevState) => ({
       showSidebar: !prevState.showSidebar
     }));
+  }
+
+  createPoll = () => {
+    this.pollInterval = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+  }
+
+  clearPoll = () => {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+    }
   }
 
   isInternalPage = () => {

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
@@ -13,7 +13,7 @@ import Navigation from './Navigation';
 import AddressBar from './AddressBar';
 import styles from './AuthenticatedLayout.scss';
 
-const POLL_FREQUENCY = 5000;
+const POLL_FREQUENCY = 10000; // 10 seconds
 
 export default class AuthenticatedLayout extends React.PureComponent {
   static propTypes = {

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
@@ -19,6 +19,7 @@ export default class AuthenticatedLayout extends React.PureComponent {
   static propTypes = {
     activeSessionId: string.isRequired,
     tabs: objectOf(tabShape).isRequired,
+    currentNetwork: string.isRequired,
     children: node,
     getLastBlock: func
   };
@@ -34,12 +35,21 @@ export default class AuthenticatedLayout extends React.PureComponent {
 
   componentDidMount() {
     this.props.getLastBlock();
-    this.timeout = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+    this.pollInterval = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.currentNetwork !== prevProps.currentNetwork) {
+      if (this.pollInterval) {
+        clearInterval(this.pollInterval);
+      }
+      this.pollInterval = setInterval(this.props.getLastBlock, POLL_FREQUENCY);
+    }
   }
 
   componentWillUnmount() {
-    if (this.timeout) {
-      clearInterval(this.timeout);
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
     }
   }
 

--- a/src/renderer/root/components/AuthenticatedLayout/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/index.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import { withActions, withData, progressValues } from 'spunky';
 import { isEqual } from 'lodash';
 
+import authActions from 'login/actions/authActions';
+import balancesActions from 'shared/actions/balancesActions';
 import blockActions from 'shared/actions/blockActions';
 import withAuthState from 'login/hocs/withAuthState';
 import withNetworkData from 'shared/hocs/withNetworkData';
@@ -18,8 +20,14 @@ const mapStateToProps = (state) => {
   return { tabs, activeSessionId };
 };
 
+const mapAuthDataToProps = ({ address }) => ({ address });
+
 const mapBlockActionsToProps = (actions, props) => ({
   getLastBlock: () => actions.call({ net: props.currentNetwork })
+});
+
+const mapBalancesDataToProps = (actions, props) => ({
+  getBalances: () => actions.call({ net: props.currentNetwork, address: props.address })
 });
 
 const mapBlockDataToProps = (block) => ({ block });
@@ -30,11 +38,14 @@ export default compose(
   withNetworkData('currentNetwork'),
   withActions(blockActions, mapBlockActionsToProps),
 
-  // Whenever a new block is received, notify all dApps.
+  // Whenever a new block is received, notify all dApps & update account balances.
+  withData(authActions, mapAuthDataToProps),
   withData(blockActions, mapBlockDataToProps),
+  withActions(balancesActions, mapBalancesDataToProps),
   withProgressChange(blockActions, LOADED, (state, props, prevProps) => {
     if (!isEqual(props.block, prevProps.block)) {
       notifyWebviews('event', 'block', props.block);
+      props.getBalances();
     }
   })
 )(AuthenticatedLayout);


### PR DESCRIPTION
## Description
This adds automatic refreshing for account balances whenever a new block is received.

## Motivation and Context
The account screen currently does not update and has no mechanism for updating, not even when sending assets.

## How Has This Been Tested?
* Opened the account screen, and observed a single balances data fetch.
* Watched for new blocks being successfully received in redux store.
* Observe balances data re-fetch.
* Ensure that account screen doesn't change to "Loading" messaging between fetching.
* Ensure that account screen does change to "Loading" messaging when changing networks.

## Screenshots (if appropriate)


## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #475.