### PR TITLE
chore(ci): fixed win32 deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,12 @@ workflows:
               ignore: /.*/
             tags:
               only: /[0-9]+(\.[0-9]+)+.*/
+      - deploy_win32:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)+.*/
       - deploy_linux:
           filters:
             branches:


### PR DESCRIPTION
## Description
This adds a missing piece to the CircleCI config so that win32 binaries get built.

## Motivation and Context
We had the steps in there, but we weren't kicking it off.

## How Has This Been Tested?
It hasn't, no one has a win32 machine.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A