### PR TITLE
chore(api): fixed ipc early unsubscribe

### DIFF
--- a/static/preloadRenderer.js
+++ b/static/preloadRenderer.js
@@ -10,16 +10,17 @@ function createDelegate(channel) {
     const successChannel = `${channel}-success-${id}`;
     const failureChannel = `${channel}-failure-${id}`;
 
-    try {
-      ipcRenderer.once(successChannel, (event, ...successArgs) => resolve(...successArgs));
-      ipcRenderer.once(failureChannel, (event, message) => reject(new Error(message)));
-      ipcRenderer.sendToHost(channel, id, ...args);
-    } catch (err) {
-      reject(err);
-    } finally {
-      ipcRenderer.removeAllListeners(successChannel);
+    ipcRenderer.once(successChannel, (event, ...successArgs) => {
       ipcRenderer.removeAllListeners(failureChannel);
-    }
+      resolve(...successArgs);
+    });
+
+    ipcRenderer.once(failureChannel, (event, message) => {
+      ipcRenderer.removeAllListeners(successChannel);
+      reject(new Error(message));
+    });
+
+    ipcRenderer.sendToHost(channel, id, ...args);
   });
 }
 


### PR DESCRIPTION
## Description
This fixes an issue I accidentally introduced as part of #530.  nOS API functions were not being resolved or rejected due to IPC listeners unsubscribing early.

## Motivation and Context
This is a core feature of the app that has to work.

## How Has This Been Tested?
Called directly from the browser console:

```js
window.NOS.V1.getAddress().then(alert).catch(alert);
```

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A