### PR TITLE
chore(menu): fixed reload button error for account/settings

### DIFF
--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -10,6 +10,7 @@ const NULL_WEBVIEW = {
   isDevToolsOpened: () => false,
   goBack: noop,
   goForward: noop,
+  reload: noop,
   on: noop,
   addListener: noop,
   removeListener: noop


### PR DESCRIPTION
## Description
Fixed an error caused by reloading while on the account or settings pages.

## Motivation and Context
Reload/back/forward don't work while on the account or settings pages.

## How Has This Been Tested?
Pressing reload button while on the account or settings screen.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #547.