### PR TITLE
feat(ledger): sign invocations

### DIFF
--- a/__tests__/renderer/browser/util/validateInvokeArgs.test.js
+++ b/__tests__/renderer/browser/util/validateInvokeArgs.test.js
@@ -4,40 +4,47 @@ import { NEO, GAS } from 'shared/values/assets';
 describe('validateInvokeArgs', () => {
   const scriptHash = '85e9cc1f18fcebf9eb8211a128807e38d094542a';
   const operation = 'transfer';
+  const args = [];
   const assets = { [NEO]: '5', [GAS]: '5.00000001' };
 
   it('does not throw for valid arguments', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation, assets })).not.toThrow();
+    expect(() => validateInvokeArgs({ scriptHash, operation, args, assets })).not.toThrow();
   });
 
   it('does not throw for null assets', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation, assets: null })).not.toThrow();
+    expect(() => validateInvokeArgs({ scriptHash, operation, args, assets: null })).not.toThrow();
   });
 
   it('does not throw for undefined assets', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation })).not.toThrow();
+    expect(() => validateInvokeArgs({ scriptHash, operation, args })).not.toThrow();
   });
 
   it('throws for invalid scriptHash', () => {
-    expect(() => validateInvokeArgs({ scriptHash: 'bad', operation, assets })).toThrow(
+    expect(() => validateInvokeArgs({ scriptHash: 'bad', operation, args, assets })).toThrow(
       'Invalid script hash: "bad"'
     );
   });
 
   it('throws for invalid operation', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation: '', assets })).toThrow(
+    expect(() => validateInvokeArgs({ scriptHash, operation: '', args, assets })).toThrow(
       'Invalid operation: ""'
     );
   });
 
+  it('throws for invalid args type', () => {
+    expect(() => validateInvokeArgs({ scriptHash, operation, args: '', assets })).toThrow(
+      'Invalid arguments: ""'
+    );
+  });
+
   it('throws for invalid assets type', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation, assets: 5 })).toThrow(
+    expect(() => validateInvokeArgs({ scriptHash, operation, args, assets: 5 })).toThrow(
       'Invalid assets: 5'
     );
   });
 
   it('throws for invalid assets shape', () => {
-    expect(() => validateInvokeArgs({ scriptHash, operation, assets: { foo: 'bar' } })).toThrow(
+    expect(() => validateInvokeArgs({ scriptHash, operation, args, assets: { foo: 'bar' } })).toThrow(
       'Invalid assets: {"foo":"bar"}'
     );
   });

--- a/__tests__/renderer/login/actions/authActions.test.js
+++ b/__tests__/renderer/login/actions/authActions.test.js
@@ -1,0 +1,123 @@
+import { wallet } from '@cityofzion/neon-js';
+
+import authActions from 'login/actions/authActions';
+
+describe('authActions', () => {
+  describe('call', () => {
+    const wif = 'KxB52D1FGe5xBn6YeezNwj7grhkHZxq7bv2tmaCPoT4rxApMwMvU';
+    const address = 'ASJQLBnhAs6fSgBv2R7KtRZjC8A9fAmcNW';
+    const privateKey = '1c7a992d0e68b7b23cb430ba596bd68cecde042410d81e9e95ee19dc1bcd739d';
+
+    const itBehavesLikeAnActionResponse = (callback) => {
+      it('returns an action object', () => {
+        expect(authActions.call(callback())).toEqual({
+          batch: false,
+          type: 'auth/ACTION/CALL',
+          meta: {
+            id: 'auth',
+            type: 'ACTION/CALL'
+          },
+          payload: {
+            fn: expect.any(Function)
+          }
+        });
+      });
+    };
+
+    describe('WIF authentication', () => {
+      itBehavesLikeAnActionResponse(() => ({ wif }));
+
+      describe('with valid WIF', () => {
+        it('returns authenticated account data', async () => {
+          const call = authActions.call({ wif });
+          expect(await call.payload.fn({})).toEqual({ wif, address });
+        });
+      });
+    });
+
+    describe('private key authentication', () => {
+      itBehavesLikeAnActionResponse(() => ({ wif: privateKey }));
+
+      describe('with valid private key', () => {
+        it('returns authenticated account data', async () => {
+          const call = authActions.call({ wif: privateKey });
+          expect(await call.payload.fn({})).toEqual({ wif, address });
+        });
+      });
+
+      describe('with invalid private key', () => {
+        it('throws an error', () => {
+          expect.assertions(1);
+          const call = authActions.call({ wif: 'invalid' });
+          return expect(call.payload.fn({})).rejects.toEqual(
+            new Error('That is not a valid private key.')
+          );
+        });
+      });
+    });
+
+    describe('passphrase authentication', () => {
+      const account = new wallet.Account(wif);
+      const passphrase = 'valid';
+
+      beforeAll(() => {
+        account.encrypt(passphrase);
+      });
+
+      itBehavesLikeAnActionResponse(() => ({ encryptedWIF: account.encrypted, passphrase }));
+
+      describe('with valid encrypted key & passphrase', () => {
+        it('returns authenticated account data', async () => {
+          const call = authActions.call({ encryptedWIF: account.encrypted, passphrase });
+          expect(await call.payload.fn({})).toEqual({ wif, address });
+        });
+      });
+
+      describe('with invalid encrypted key', () => {
+        it('throws an error', () => {
+          expect.assertions(1);
+          const call = authActions.call({ encryptedWIF: 'invalid', passphrase });
+          return expect(call.payload.fn({})).rejects.toEqual(
+            new Error('That is not a valid encrypted key.')
+          );
+        });
+      });
+
+      describe('with invalid passphrase', () => {
+        it('throws an error', () => {
+          expect.assertions(1);
+          const call = authActions.call({ encryptedWIF: account.encrypted, passphrase: 'invalid' });
+          return expect(call.payload.fn({})).rejects.toEqual(
+            new Error('Wrong Password or scrypt parameters!')
+          );
+        });
+      });
+    });
+  });
+
+  describe('cancel', () => {
+    it('returns an action object', () => {
+      expect(authActions.cancel()).toEqual({
+        batch: false,
+        type: 'auth/ACTION/CANCEL',
+        meta: {
+          id: 'auth',
+          type: 'ACTION/CANCEL'
+        }
+      });
+    });
+  });
+
+  describe('reset', () => {
+    it('returns an action object', () => {
+      expect(authActions.reset()).toEqual({
+        batch: false,
+        type: 'auth/ACTION/RESET',
+        meta: {
+          id: 'auth',
+          type: 'ACTION/RESET'
+        }
+      });
+    });
+  });
+});

--- a/src/renderer/browser/actions/makeInvokeActions.js
+++ b/src/renderer/browser/actions/makeInvokeActions.js
@@ -1,35 +1,38 @@
 import { createActions } from 'spunky';
 import { wallet, api } from '@cityofzion/neon-js';
-import { isArray, mapKeys } from 'lodash';
+import { mapKeys } from 'lodash';
 
 import createScript from 'shared/util/createScript';
 import formatAssets from 'shared/util/formatAssets';
 import { ASSETS } from 'shared/values/assets';
 
 import generateDAppActionId from './generateDAppActionId';
+import validateInvokeArgs from '../util/validateInvokeArgs';
 
 export const ID = 'invoke';
 
 async function doInvoke({
-  net, address, wif, scriptHash, operation, assets, args, encodeArgs = true, fee = 0
+  net,
+  address,
+  wif,
+  publicKey,
+  signingFunction,
+  scriptHash,
+  operation,
+  assets,
+  args,
+  encodeArgs = true,
+  fee = 0
 }) {
-  if (!wallet.isScriptHash(scriptHash)) {
-    throw new Error(`Invalid script hash: "${scriptHash}"`);
-  }
-
-  if (typeof operation !== 'string') {
-    throw new Error(`Invalid operation: "${operation}"`);
-  }
-
-  if (!isArray(args)) {
-    throw new Error(`Invalid arguments: "${args}"`);
-  }
+  validateInvokeArgs({ scriptHash, operation, args, assets });
 
   const config = {
     net,
     address,
     script: createScript(scriptHash, operation, args, encodeArgs),
     privateKey: wif,
+    publicKey,
+    signingFunction,
     gas: 0,
     fees: fee
   };

--- a/src/renderer/browser/actions/makeInvokeActions.js
+++ b/src/renderer/browser/actions/makeInvokeActions.js
@@ -43,7 +43,7 @@ async function doInvoke({
     config.intents = api.makeIntent(intentConfig, scAddress);
   }
 
-  const { response: { result, txid } } = await api.doInvoke(config);
+  const { response: { result, txid } } = await api.doInvoke(config, api.neoscan);
 
   if (!result) {
     throw new Error('Invocation failed.');

--- a/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
@@ -20,7 +20,7 @@ const CONFIG_KEYS = ['scriptHash', 'operation', 'args', 'encodeArgs', 'assets'];
 const mapAuthDataToProps = (data) => data;
 const mapInvokeDataToProps = (txid) => ({ txid });
 
-export default function makeInvoke(invokeActions) {
+export default function makeInvoke(invokeActions, balancesActions) {
   return compose(
     // Clean redux store when done
     withClean(invokeActions),
@@ -32,7 +32,7 @@ export default function makeInvoke(invokeActions) {
     withValidation(validateInvokeArgs),
 
     // Prompt user
-    withInvocationPrompt,
+    withInvocationPrompt(balancesActions),
 
     // Get the current network and account data
     withNetworkData(),

--- a/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
+++ b/src/renderer/browser/components/RequestsProcessor/Invoke/index.js
@@ -11,12 +11,13 @@ import withClean from '../../../hocs/withClean';
 import withInvocationPrompt from '../../../hocs/withInvocationPrompt';
 import withNullLoader from '../../../hocs/withNullLoader';
 import withRejectMessage from '../../../hocs/withRejectMessage';
+import withSignTransactionToast from '../../../hocs/withSignTransactionToast';
 import withValidation from '../../../hocs/withValidation';
 import validateInvokeArgs from '../../../util/validateInvokeArgs';
 
 const CONFIG_KEYS = ['scriptHash', 'operation', 'args', 'encodeArgs', 'assets'];
 
-const mapAuthDataToProps = ({ address, wif }) => ({ address, wif });
+const mapAuthDataToProps = (data) => data;
 const mapInvokeDataToProps = (txid) => ({ txid });
 
 export default function makeInvoke(invokeActions) {
@@ -42,6 +43,8 @@ export default function makeInvoke(invokeActions) {
       net,
       address,
       wif,
+      publicKey,
+      signingFunction,
       scriptHash,
       operation,
       args,
@@ -51,12 +54,15 @@ export default function makeInvoke(invokeActions) {
       net,
       address,
       wif,
+      publicKey,
+      signingFunction,
       scriptHash,
       operation,
       args,
       assets,
       encodeArgs
     })),
+    withSignTransactionToast,
     withNullLoader(invokeActions),
     withRejectMessage(invokeActions, ({ operation, scriptHash, error }) => (
       `Could not perform operation '${operation}' on contract with address '${scriptHash}': ${error}`

--- a/src/renderer/browser/components/RequestsProcessor/RequestProcessor.js
+++ b/src/renderer/browser/components/RequestsProcessor/RequestProcessor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { string, func } from 'prop-types';
-import { isEqual } from 'lodash';
+import { isEqual, castArray } from 'lodash';
 
 import { getComponent, getActions } from './mappings';
 import requestShape from '../../shapes/requestShape';
@@ -54,8 +54,8 @@ export default class RequestProcessor extends React.PureComponent {
   getComponent = ({ sessionId, request }) => {
     const makeComponent = getComponent(request.channel);
     const makeActions = getActions(request.channel);
-    const actions = makeActions(sessionId, request.id);
+    const actions = castArray(makeActions).map((makeAction) => makeAction(sessionId, request.id));
 
-    return makeComponent(actions);
+    return makeComponent(...actions);
   }
 }

--- a/src/renderer/browser/components/RequestsProcessor/mappings.js
+++ b/src/renderer/browser/components/RequestsProcessor/mappings.js
@@ -28,7 +28,7 @@ const ACTIONS_MAP = {
   getStorage: makeStorageActions,
   getBalance: makeBalancesActions,
   testInvoke: makeTestInvokeActions,
-  invoke: makeInvokeActions,
+  invoke: [makeInvokeActions, makeBalancesActions],
   send: makeSendActions,
   claimGas: makeClaimActions
 };

--- a/src/renderer/browser/hocs/withInvocationPrompt/index.js
+++ b/src/renderer/browser/hocs/withInvocationPrompt/index.js
@@ -2,7 +2,6 @@ import { compose } from 'recompose';
 import { withCall, withData } from 'spunky';
 
 import authActions from 'login/actions/authActions';
-import balancesActions from 'shared/actions/balancesActions';
 import withNetworkData from 'shared/hocs/withNetworkData';
 
 import InvocationPrompt from './InvocationPrompt';
@@ -12,11 +11,13 @@ import withPrompt from '../withPrompt';
 const mapAuthDataToProps = ({ address }) => ({ address });
 const mapBalancesDataToProps = (balances) => ({ balances });
 
-export default compose(
-  withNetworkData(),
-  withData(authActions, mapAuthDataToProps),
-  withCall(balancesActions),
-  withNullLoader(balancesActions),
-  withData(balancesActions, mapBalancesDataToProps),
-  withPrompt(InvocationPrompt, { title: null })
-);
+export default function withInvocationPrompt(balancesActions) {
+  return compose(
+    withNetworkData(),
+    withData(authActions, mapAuthDataToProps),
+    withCall(balancesActions),
+    withNullLoader(balancesActions),
+    withData(balancesActions, mapBalancesDataToProps),
+    withPrompt(InvocationPrompt, { title: null })
+  );
+}

--- a/src/renderer/browser/hocs/withSignTransactionToast.js
+++ b/src/renderer/browser/hocs/withSignTransactionToast.js
@@ -1,0 +1,24 @@
+import { compose, branch, lifecycle } from 'recompose';
+import { withData } from 'spunky';
+
+import authActions from 'login/actions/authActions';
+
+import { withInfoToast } from 'shared/hocs/withToast';
+
+const mapAuthDataToProps = ({ signingFunction }) => ({
+  requiresSignature: !!signingFunction
+});
+
+const withSignTransactionToast = compose(
+  withInfoToast(),
+  lifecycle({
+    componentDidMount() {
+      this.props.showInfoToast('Please sign the the transaction on your Ledger.');
+    }
+  })
+);
+
+export default compose(
+  withData(authActions, mapAuthDataToProps),
+  branch((props) => !!props.requiresSignature, withSignTransactionToast)
+);

--- a/src/renderer/browser/util/validateInvokeArgs.js
+++ b/src/renderer/browser/util/validateInvokeArgs.js
@@ -1,17 +1,21 @@
 import { wallet } from '@cityofzion/neon-js';
-import { some, isString, isObject, isEmpty } from 'lodash';
+import { some, isString, isObject, isArray, isEmpty } from 'lodash';
 
 import isValidAsset from './isValidAsset';
 
 const isInvalidAsset = (amount, assetId) => !isValidAsset(assetId, amount);
 
-export default function validateInvokeArgs({ scriptHash, operation, assets }) {
+export default function validateInvokeArgs({ scriptHash, operation, args, assets }) {
   if (!wallet.isScriptHash(scriptHash)) {
     throw new Error(`Invalid script hash: "${scriptHash}"`);
   }
 
   if (!isString(operation) || isEmpty(operation)) {
     throw new Error(`Invalid operation: "${operation}"`);
+  }
+
+  if (!isArray(args)) {
+    throw new Error(`Invalid arguments: "${args}"`);
   }
 
   if (assets && (!isObject(assets) || some(assets, isInvalidAsset))) {

--- a/src/renderer/login/actions/authActions.js
+++ b/src/renderer/login/actions/authActions.js
@@ -5,8 +5,6 @@ import { signWithLedger } from '../util/ledger';
 
 export const ID = 'auth';
 
-const MIN_PASSPHRASE_LEN = 4;
-
 const wifAuthenticate = (wif) => {
   if (!wallet.isWIF(wif) && !wallet.isPrivateKey(wif)) {
     throw new Error('That is not a valid private key.');
@@ -18,10 +16,6 @@ const wifAuthenticate = (wif) => {
 };
 
 const nep2Authenticate = async (passphrase, encryptedWIF) => {
-  if (passphrase.length < MIN_PASSPHRASE_LEN) {
-    throw new Error('Passphrase is too short.');
-  }
-
   if (!wallet.isNEP2(encryptedWIF)) {
     throw new Error('That is not a valid encrypted key.');
   }

--- a/src/renderer/login/actions/authActions.js
+++ b/src/renderer/login/actions/authActions.js
@@ -1,7 +1,7 @@
 import { wallet } from '@cityofzion/neon-js';
 import { createActions } from 'spunky';
 
-// import { ledgerNanoSCreateSignatureAsync } from '../ledger/ledgerNanoS';
+import { signWithLedger } from '../util/ledger';
 
 export const ID = 'auth';
 
@@ -35,9 +35,8 @@ const nep2Authenticate = async (passphrase, encryptedWIF) => {
 const ledgerAuthenticate = (publicKey) => {
   const publicKeyEncoded = wallet.getPublicKeyEncoded(publicKey);
   const account = new wallet.Account(publicKeyEncoded);
-  const signingFunction = null; // ledgerNanoSCreateSignatureAsync
 
-  return { publicKey, address: account.address, signingFunction };
+  return { publicKey, address: account.address, signingFunction: signWithLedger };
 };
 
 export default createActions(ID, ({ wif, passphrase, encryptedWIF, publicKey }) => async () => {

--- a/src/renderer/login/util/ledger.js
+++ b/src/renderer/login/util/ledger.js
@@ -2,8 +2,10 @@ import LedgerNode from '@ledgerhq/hw-transport-node-hid';
 import { tx, wallet, u } from '@cityofzion/neon-js';
 
 const VALID_STATUS = 0x9000;
-const MSG_TOO_BIG = 0x6D08;
+const MSG_TOO_BIG = 0x6d08;
 const APP_CLOSED = 0x6e00;
+const TX_DENIED = 0x6985;
+const TX_PARSE_ERR = 0x6d07;
 
 const evalTransportError = (err) => {
   switch (err.statusCode) {
@@ -11,6 +13,10 @@ const evalTransportError = (err) => {
       return new Error('Please open the NEO app on your Ledger device.');
     case MSG_TOO_BIG:
       return new Error('Your transaction is too large for Ledger to sign.');
+    case TX_DENIED:
+      return new Error('You have denied the transaction on your ledger.');
+    case TX_PARSE_ERR:
+      return new Error('Error parsing transaction. Ensure your NEO Ledger app is up to date.');
     default:
       return err;
   }


### PR DESCRIPTION
## Description
Adds Ledger support for invocation transactions.

**Note:** There is a bug with two toasts displaying instead of one that I haven't figured out yet.  I'll figure this out as a follow-up to this PR since it's pretty minor.

## Motivation and Context
Ledger users cannot currently complete invocation transactions successfully.

## How Has This Been Tested?
1. Log in with Ledger.
2. Open a create-react-app app that defines an invocation.
3. Click "Confirm" in the invocation prompt.
4. Sign or decline the transaction on the Ledger device.

## Screenshots (if appropriate)
![ledger-invocation](https://user-images.githubusercontent.com/169093/45919673-d3896400-be5e-11e8-9707-4ca11e99d048.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #560.