### PR TITLE
chore(favicon): use nos favicon for internal links

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/FavIcon/FavIcon.js
+++ b/src/renderer/root/components/AuthenticatedLayout/FavIcon/FavIcon.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import classNames from 'classnames';
+import { string, oneOf } from 'prop-types';
+
+import DefaultIcon from 'shared/images/browser/favicon.svg';
+import NosIcon from 'shared/images/browser/favicon-nos.svg';
+import { INTERNAL, EXTERNAL } from 'browser/values/browserValues';
+
+import styles from './FavIcon.scss';
+
+export default function FavIcon(props) {
+  const { icon, type, title } = props;
+  const className = classNames(styles.favIcon, props.className);
+
+  if (icon) {
+    return <img className={className} src={icon} alt={title} />;
+  } else if (type === INTERNAL) {
+    return <NosIcon className={className} />;
+  } else {
+    return <DefaultIcon className={className} />;
+  }
+}
+
+FavIcon.propTypes = {
+  title: string.isRequired,
+  type: oneOf([INTERNAL, EXTERNAL]).isRequired,
+  icon: string
+};

--- a/src/renderer/root/components/AuthenticatedLayout/FavIcon/FavIcon.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/FavIcon/FavIcon.scss
@@ -1,0 +1,5 @@
+.favIcon {
+  width: 16px;
+  height: 16px;
+  color: $light-text-color;
+}

--- a/src/renderer/root/components/AuthenticatedLayout/FavIcon/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/FavIcon/index.js
@@ -1,0 +1,1 @@
+export { default } from './FavIcon';

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import { bool, string, func } from 'prop-types';
+import { bool, string, func, oneOf } from 'prop-types';
 import { noop } from 'lodash';
 
 import Icon from 'shared/components/Icon';
 import FavIcon from 'shared/images/browser/favicon.svg';
+import NosIcon from 'shared/images/browser/favicon-nos.svg';
+import { INTERNAL, EXTERNAL } from 'browser/values/browserValues';
 
 import styles from './Tab.scss';
 
@@ -13,6 +15,7 @@ export default class Tab extends React.PureComponent {
     className: string,
     active: bool,
     title: string.isRequired,
+    type: oneOf([INTERNAL, EXTERNAL]).isRequired,
     icon: string,
     loading: bool,
     onClick: func,
@@ -50,12 +53,14 @@ export default class Tab extends React.PureComponent {
   }
 
   renderIcon = () => {
-    const { loading, icon, title } = this.props;
+    const { loading, icon, title, type } = this.props;
 
     if (loading) {
       return <Icon className={styles.loading} name="spin" />;
     } else if (icon) {
       return <img className={styles.icon} src={icon} alt={title} />;
+    } else if (type === INTERNAL) {
+      return <NosIcon className={styles.icon} />;
     } else {
       return <FavIcon className={styles.icon} />;
     }

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.js
@@ -4,10 +4,9 @@ import { bool, string, func, oneOf } from 'prop-types';
 import { noop } from 'lodash';
 
 import Icon from 'shared/components/Icon';
-import FavIcon from 'shared/images/browser/favicon.svg';
-import NosIcon from 'shared/images/browser/favicon-nos.svg';
 import { INTERNAL, EXTERNAL } from 'browser/values/browserValues';
 
+import FavIcon from '../FavIcon';
 import styles from './Tab.scss';
 
 export default class Tab extends React.PureComponent {
@@ -57,12 +56,8 @@ export default class Tab extends React.PureComponent {
 
     if (loading) {
       return <Icon className={styles.loading} name="spin" />;
-    } else if (icon) {
-      return <img className={styles.icon} src={icon} alt={title} />;
-    } else if (type === INTERNAL) {
-      return <NosIcon className={styles.icon} />;
     } else {
-      return <FavIcon className={styles.icon} />;
+      return <FavIcon className={styles.icon} icon={icon} type={type} title={title} />;
     }
   }
 

--- a/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Tab/Tab.scss
@@ -45,12 +45,6 @@
     @include spin;
   }
 
-  .icon {
-    width: 16px;
-    height: 16px;
-    color: $light-text-color;
-  }
-
   .loading,
   .icon {
     flex: 0 0 auto;

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -44,7 +44,7 @@ export default class Tabs extends React.PureComponent {
   }
 
   renderTab = (tab, sessionId) => {
-    const { target, title, icon, loading } = tab;
+    const { target, title, type, icon, loading } = tab;
 
     return (
       <Tab
@@ -52,6 +52,7 @@ export default class Tabs extends React.PureComponent {
         className={styles.tab}
         target={target}
         title={title}
+        type={type}
         icon={icon}
         loading={loading}
         active={sessionId === this.props.activeSessionId}

--- a/src/renderer/shared/images/browser/favicon-nos.svg
+++ b/src/renderer/shared/images/browser/favicon-nos.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2 8C2 4.68628 4.68628 2 8 2C11.3137 2 14 4.68628 14 8C14 11.3137 11.3137 14 8 14C4.68628 14 2 11.3137 2 8ZM4 8C4 10.2092 5.79077 12 8 12C10.2092 12 12 10.2092 12 8C12 5.79077 10.2092 4 8 4C5.79077 4 4 5.79077 4 8Z" fill="url(#paint0_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="2" y1="14" x2="14" y2="14" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B9D532"/>
+<stop offset="1" stop-color="#5BBA47"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Description
This updates the account and settings tabs to use the nOS icon as the favicon.

## Motivation and Context
Using the nOS icon to highlight nOS content will help the to distinguish it from other tabs.

## How Has This Been Tested?
Opening the account and settings tabs, as well as other websites.

## Screenshots (if appropriate)
<img width="1023" alt="screen shot 2018-09-27 at 12 00 33 am" src="https://user-images.githubusercontent.com/169093/46124235-830c6080-c1e8-11e8-9e0b-5d1ca49d1adb.png">

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A