### PR TITLE
chore(menu): fix reload accelerator

### DIFF
--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -53,7 +53,7 @@ function bindAppMenu(webview) {
         },
         {
           label: 'Reload',
-          accelorator: 'CmdOrCtrl+R',
+          accelerator: 'CmdOrCtrl+R',
           enabled: webview !== NULL_WEBVIEW && !webview.isLoading(),
           click: () => webview.reload()
         },


### PR DESCRIPTION
## Description
This fixes the "Reload" menu accelerator (shortcut key).

## Motivation and Context
A simple typo prevented Cmd+R / Ctrl+R from working for reloading the page.

## How Has This Been Tested?
Loading a webpage, then pressing Cmd+R.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A