### PR TITLE
feat(menu) open tab, open location, close tab, & shortcut keys

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -19,6 +19,8 @@ module.exports = {
   },
 
   ipcRenderer: {
-    send: noop
+    send: noop,
+    on: noop,
+    removeListener: noop
   }
 };

--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -33,9 +33,20 @@ function bindAppMenu(browserWindow, webview) {
       label: 'File',
       submenu: [
         {
+          label: 'New Tab',
+          accelerator: 'CmdOrCtrl+T',
+          click: () => browserWindow.webContents.send('file:new-tab')
+        },
+        {
           label: 'Open Location',
           accelerator: 'CmdOrCtrl+L',
           click: () => browserWindow.webContents.send('file:open-location')
+        },
+        { type: 'separator' },
+        {
+          label: 'Close Tab',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => browserWindow.webContents.send('file:close-tab')
         }
       ]
     },
@@ -110,8 +121,7 @@ function bindAppMenu(browserWindow, webview) {
     {
       role: 'window',
       submenu: [
-        { role: 'minimize' },
-        { role: 'close' }
+        { role: 'minimize' }
       ]
     },
     {
@@ -156,7 +166,6 @@ function bindAppMenu(browserWindow, webview) {
 
     // Window menu
     find(template, { role: 'window' }).submenu = [
-      { role: 'close' },
       { role: 'minimize' },
       { role: 'zoom' },
       { type: 'separator' },

--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -8,6 +8,7 @@ const NULL_WEBVIEW = {
   canGoBack: () => false,
   canGoForward: () => false,
   isDevToolsOpened: () => false,
+  send: noop,
   goBack: noop,
   goForward: noop,
   reload: noop,
@@ -26,8 +27,18 @@ function getWebview(id) {
   return find(allWebContents, (wc) => wc.getId() === id) || NULL_WEBVIEW;
 }
 
-function bindAppMenu(webview) {
+function bindAppMenu(browserWindow, webview) {
   const template = [
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Open Location',
+          accelerator: 'CmdOrCtrl+L',
+          click: () => browserWindow.webContents.send('file:open-location')
+        }
+      ]
+    },
     {
       label: 'Edit',
       submenu: [
@@ -163,7 +174,7 @@ export default function bindMenu(browserWindow) {
 
   function replaceMenu() {
     const oldMenu = menu;
-    menu = bindAppMenu(webview);
+    menu = bindAppMenu(browserWindow, webview);
     if (oldMenu) oldMenu.destroy();
   }
 

--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -197,6 +197,17 @@ function registerShortcuts(browserWindow, getActiveWebview) {
   localShortcut.register(browserWindow, 'CmdOrCtrl+9', () => {
     browserWindow.webContents.send('window:goto-tab', 'last');
   });
+
+  // mouse buttons (Windows only)
+  browserWindow.on('app-command', (event, command) => {
+    if (command === 'browser-backward') {
+      getActiveWebview().goBack();
+    } else if (command === 'browser-forward') {
+      getActiveWebview().goForward();
+    } else if (command === 'close') {
+      browserWindow.webContents.send('file:close-tab');
+    }
+  });
 }
 
 export default function bindMenu(browserWindow) {

--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -169,6 +169,17 @@ function bindAppMenu(browserWindow, webview) {
       { role: 'minimize' },
       { role: 'zoom' },
       { type: 'separator' },
+      {
+        label: 'Select Next Tab',
+        accelerator: 'Ctrl+Tab',
+        click: () => browserWindow.webContents.send('window:next-tab')
+      },
+      {
+        label: 'Select Previous Tab',
+        accelerator: 'Shift+Ctrl+Tab',
+        click: () => browserWindow.webContents.send('window:previous-tab')
+      },
+      { type: 'separator' },
       { role: 'front' }
     ];
   }

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { func, string, bool } from 'prop-types';
 import { noop, isEmpty } from 'lodash';
+import { ipcRenderer } from 'electron';
 
 import SidebarIcon from 'shared/images/icons/sidebar.svg';
 import SidebarActiveIcon from 'shared/images/icons/sidebar-active.svg';
@@ -39,11 +40,19 @@ export default class AddressBar extends React.PureComponent {
     disabled: false
   };
 
+  componentDidMount() {
+    ipcRenderer.on('file:open-location', this.handleOpenLocation);
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.query !== prevProps.query) {
       this.input.value = this.props.query;
       this.input.blur();
     }
+  }
+
+  componentWillUnmount() {
+    ipcRenderer.removeAllListeners('file:open-location');
   }
 
   render() {
@@ -112,6 +121,11 @@ export default class AddressBar extends React.PureComponent {
     if (isEmpty(selection.toString())) {
       this.input.select();
     }
+  }
+
+  handleOpenLocation = () => {
+    this.input.select();
+    this.input.focus();
   }
 
   registerRef = (el) => {

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
@@ -13,8 +13,6 @@ import NotificationsIcon from 'shared/images/icons/notifications.svg';
 
 import styles from './AddressBar.scss';
 
-const RETURN_KEY = 13;
-
 export default class AddressBar extends React.PureComponent {
   static propTypes = {
     className: string,
@@ -106,8 +104,11 @@ export default class AddressBar extends React.PureComponent {
   };
 
   handleKeyDown = (event) => {
-    if (event.which === RETURN_KEY) {
+    if (event.key === 'Enter') {
       this.props.onQuery(event.target.value);
+    } else if (event.key === 'Escape') {
+      this.input.value = this.props.query;
+      this.input.select();
     }
   }
 

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { string, objectOf, func } from 'prop-types';
-import { map, noop } from 'lodash';
+import { map, noop, keys } from 'lodash';
 import { ipcRenderer } from 'electron';
 
 import PlusIcon from 'shared/images/browser/plus.svg';
@@ -29,12 +29,14 @@ export default class Tabs extends React.PureComponent {
 
   componentDidMount() {
     ipcRenderer.on('file:new-tab', this.props.onOpen);
-    ipcRenderer.on('file:close-tab', () => this.props.onClose(this.props.activeSessionId));
+    ipcRenderer.on('file:close-tab', this.handleCloseActiveTab);
+    ipcRenderer.on('window:goto-tab', this.handleGotoTab);
   }
 
   componentWillUnmount() {
     ipcRenderer.removeAllListeners('file:new-tab');
     ipcRenderer.removeAllListeners('file:close-tab');
+    ipcRenderer.removeAllListeners('window:goto-tab');
   }
 
   render() {
@@ -75,5 +77,18 @@ export default class Tabs extends React.PureComponent {
     return () => {
       this.props.onClose(sessionId);
     };
+  }
+
+  handleCloseActiveTab = () => {
+    this.props.onClose(this.props.activeSessionId);
+  }
+
+  handleGotoTab = (event, i) => {
+    const sessionIds = keys(this.props.tabs);
+    const sessionId = i === 'last' ? sessionIds[sessionIds.length - 1] : sessionIds[i - 1];
+
+    if (sessionId) {
+      this.props.setActiveTab(sessionId);
+    }
   }
 }

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -31,12 +31,16 @@ export default class Tabs extends React.PureComponent {
     ipcRenderer.on('file:new-tab', this.props.onOpen);
     ipcRenderer.on('file:close-tab', this.handleCloseActiveTab);
     ipcRenderer.on('window:goto-tab', this.handleGotoTab);
+    ipcRenderer.on('window:next-tab', this.handleNextTab);
+    ipcRenderer.on('window:previous-tab', this.handlePreviousTab);
   }
 
   componentWillUnmount() {
     ipcRenderer.removeAllListeners('file:new-tab');
     ipcRenderer.removeAllListeners('file:close-tab');
     ipcRenderer.removeAllListeners('window:goto-tab');
+    ipcRenderer.removeAllListeners('window:next-tab');
+    ipcRenderer.removeAllListeners('window:previous-tab');
   }
 
   render() {
@@ -89,6 +93,24 @@ export default class Tabs extends React.PureComponent {
 
     if (sessionId) {
       this.props.setActiveTab(sessionId);
+    }
+  }
+
+  handleNextTab = () => {
+    this.incrementTab(1);
+  }
+
+  handlePreviousTab = () => {
+    this.incrementTab(-1);
+  }
+
+  incrementTab = (offset) => {
+    const sessionIds = keys(this.props.tabs);
+    const currentIndex = sessionIds.indexOf(this.props.activeSessionId);
+
+    if (currentIndex !== -1) {
+      const newIndex = ((currentIndex + offset) + sessionIds.length) % sessionIds.length;
+      this.props.setActiveTab(sessionIds[newIndex]);
     }
   }
 }

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { string, objectOf, func } from 'prop-types';
 import { map, noop } from 'lodash';
+import { ipcRenderer } from 'electron';
 
 import PlusIcon from 'shared/images/browser/plus.svg';
 import tabShape from 'browser/shapes/tabShape';
@@ -27,11 +28,13 @@ export default class Tabs extends React.PureComponent {
   };
 
   componentDidMount() {
-    window.addEventListener('keydown', this.handleShortcuts, true);
+    ipcRenderer.on('file:new-tab', this.props.onOpen);
+    ipcRenderer.on('file:close-tab', () => this.props.onClose(this.props.activeSessionId));
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleShortcuts);
+    ipcRenderer.removeAllListeners('file:new-tab');
+    ipcRenderer.removeAllListeners('file:close-tab');
   }
 
   render() {
@@ -72,25 +75,5 @@ export default class Tabs extends React.PureComponent {
     return () => {
       this.props.onClose(sessionId);
     };
-  }
-
-  handleShortcuts = (event) => {
-    const combinationKeyIsPressed = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
-
-    // Command + w (close current tab or client)
-    if (combinationKeyIsPressed && event.key === 'w') {
-      if (Object.keys(this.props.tabs).length > 1) {
-        // Prevent client to quit (default behavior)
-        event.preventDefault();
-        // Only close active tab if there is more than 1 tab added
-        this.props.onClose(this.props.activeSessionId);
-      }
-    }
-
-    // Command + t (open new tab)
-    if (combinationKeyIsPressed && event.key === 't') {
-      event.preventDefault();
-      this.props.onOpen();
-    }
   }
 }

--- a/src/renderer/shared/components/Forms/Input/Input.js
+++ b/src/renderer/shared/components/Forms/Input/Input.js
@@ -71,7 +71,9 @@ export default class Input extends React.PureComponent {
   }
 
   handleClick = () => {
-    this.ref.current.focus();
+    if (this.ref.current) {
+      this.ref.current.focus();
+    }
   }
 
   handleFocus = (event) => {


### PR DESCRIPTION
## Description
This removes the old code for opening/closing tabs, and replaces it with some menu items & shortcut keys.

* Open Tab (Cmd+T or Ctrl+T)
* Close Tab (Cmd+W or Ctrl+W)
* Open Location (Cmd+L or Ctrl+L) focuses the address bar
* Escape key cancels any changes within the address bar
* Cmd+(1-8) or Ctrl+(1-8) to jump to tabs 1-8
* Cmd+9 or Ctrl+9 to jump to last tab
* Windows mouse button shortcuts for back, forward, & close tab

## Motivation and Context
Making the app behave in more standard ways.

## How Has This Been Tested?
Using the menu items with both the mouse and the keyboard.

## Screenshots (if appropriate)
![open-location](https://user-images.githubusercontent.com/169093/46240418-d9a2a780-c36c-11e8-84da-99538127bd37.gif)

![tab-menu-items](https://user-images.githubusercontent.com/169093/46240419-de675b80-c36c-11e8-8d36-33ee9616728e.gif)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #341.