### PR TITLE
chore(menu): open help link in nOS when possible

### DIFF
--- a/src/main/util/bindMenus.js
+++ b/src/main/util/bindMenus.js
@@ -1,5 +1,5 @@
 import localShortcut from 'electron-localshortcut';
-import { app, shell, webContents, ipcMain, Menu } from 'electron';
+import { app, webContents, ipcMain, Menu } from 'electron';
 import { noop, find, times } from 'lodash';
 
 const isMac = process.platform === 'darwin';
@@ -129,7 +129,7 @@ function bindAppMenu(browserWindow, webview) {
       submenu: [
         {
           label: 'Learn More',
-          click() { shell.openExternal('https://nos.io'); }
+          click: () => browserWindow.webContents.send('file:new-tab', 'https://nos.io')
         }
       ]
     }

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -28,7 +28,7 @@ export default class Tabs extends React.PureComponent {
   };
 
   componentDidMount() {
-    ipcRenderer.on('file:new-tab', this.props.onOpen);
+    ipcRenderer.on('file:new-tab', this.handleOpenTab);
     ipcRenderer.on('file:close-tab', this.handleCloseActiveTab);
     ipcRenderer.on('window:goto-tab', this.handleGotoTab);
     ipcRenderer.on('window:next-tab', this.handleNextTab);
@@ -47,7 +47,7 @@ export default class Tabs extends React.PureComponent {
     return (
       <div className={classNames(styles.tabs, this.props.className)}>
         {map(this.props.tabs, this.renderTab)}
-        <PlusIcon className={styles.newTab} onClick={this.props.onOpen} />
+        <PlusIcon className={styles.newTab} onClick={this.handleNewTab} />
       </div>
     );
   }
@@ -81,6 +81,14 @@ export default class Tabs extends React.PureComponent {
     return () => {
       this.props.onClose(sessionId);
     };
+  }
+
+  handleNewTab = () => {
+    this.props.onOpen();
+  }
+
+  handleOpenTab = (event, target) => {
+    this.props.onOpen(target);
   }
 
   handleCloseActiveTab = () => {

--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/index.js
@@ -6,7 +6,7 @@ import { openTab, closeTab, setActiveTab } from 'browser/actions/browserActions'
 import Tabs from './Tabs';
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
-  onOpen: () => openTab(),
+  onOpen: (target) => openTab(target && { target }),
   onClose: (sessionId) => closeTab(sessionId),
   setActiveTab
 }, dispatch);

--- a/src/renderer/root/components/LoginLayout/LoginLayout.js
+++ b/src/renderer/root/components/LoginLayout/LoginLayout.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { node } from 'prop-types';
+import { ipcRenderer, shell } from 'electron';
 
 import styles from './LoginLayout.scss';
 
@@ -14,11 +15,25 @@ export default class LoginLayout extends React.PureComponent {
     children: null
   };
 
+  componentDidMount() {
+    ipcRenderer.on('file:new-tab', this.handleOpenTab);
+  }
+
+  componentWillUnmount() {
+    ipcRenderer.removeAllListeners('file:new-tab');
+  }
+
   render() {
     return (
       <div className={styles.loginLayout}>
         {this.props.children}
       </div>
     );
+  }
+
+  handleOpenTab = (event, target) => {
+    if (target) {
+      shell.openExternal(target);
+    }
   }
 }


### PR DESCRIPTION
## Description
The "Learn More" menu item in the "Help" menu (mac only) was being opened in an external browser.  Since nOS can behave as a browser, we should open it in there.  The only time we can't is when the user hasn't logged in yet, in which case we continue to open via shell (default browser).

## Motivation and Context
nOS is a browser, let's use it.

## How Has This Been Tested?
* Clicking the menu item while at the login screen & when logged in.
* Opening new tabs via Cmd+T & the `+` icon in the tab bar.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A