### PR TITLE
chore(menu): restore context menus

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -5,6 +5,7 @@ import url from 'url';
 
 import getStaticPath from './util/getStaticPath';
 import bindMenus from './util/bindMenus';
+import bindContextMenu from './util/bindContextMenu';
 import injectHeaders from './util/injectHeaders';
 import installExtensions from './util/installExtensions';
 import registerNosProtocol from './util/registerNosProtocol';
@@ -46,6 +47,7 @@ function createWindow() {
   );
 
   bindMenus(mainWindow);
+  bindContextMenu(mainWindow);
 
   if (isDev) {
     mainWindow.webContents.openDevTools();

--- a/src/main/util/bindContextMenu.js
+++ b/src/main/util/bindContextMenu.js
@@ -1,0 +1,49 @@
+import { Menu } from 'electron';
+
+export default function bindContextMenu(browserWindow) {
+  browserWindow.webContents.on('context-menu', (event, params) => {
+    const template = [];
+    const { isEditable, editFlags } = params;
+
+    if (isEditable) {
+      template.push({
+        label: 'Undo',
+        role: editFlags.canUndo ? 'undo' : '',
+        enabled: editFlags.canUndo
+      }, {
+        label: 'Redo',
+        role: editFlags.canRedo ? 'redo' : '',
+        enabled: editFlags.canRedo
+      }, {
+        type: 'separator'
+      }, {
+        label: 'Cut',
+        role: editFlags.canCut ? 'cut' : '',
+        enabled: editFlags.canCut
+      }, {
+        label: 'Copy',
+        role: editFlags.canCopy ? 'copy' : '',
+        enabled: editFlags.canCopy
+      }, {
+        label: 'Paste',
+        role: editFlags.canPaste ? 'paste' : '',
+        enabled: editFlags.canPaste
+      }, {
+        label: 'Paste and Match Style',
+        role: editFlags.canPaste ? 'pasteandmatchstyle' : '',
+        enabled: editFlags.canPaste
+      }, {
+        label: 'Select All',
+        role: editFlags.canSelectAll ? 'selectall' : '',
+        enabled: editFlags.canSelectAll
+      });
+    }
+
+    if (template.length === 0) {
+      return;
+    }
+
+    const menu = Menu.buildFromTemplate(template);
+    menu.popup(browserWindow);
+  });
+}


### PR DESCRIPTION
## Description
This restores the context menus for input elements throughout the app.

## Motivation and Context
I unintentionally removed this logic as part of #538.

## How Has This Been Tested?
Right clicking various inputs (text, password, etc.)

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #614