### PR TITLE
feat(claim): add claim gas button to account screen

### DIFF
--- a/src/renderer/account/components/Account/Account.js
+++ b/src/renderer/account/components/Account/Account.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { objectOf, number } from 'prop-types';
+import { objectOf, number, string } from 'prop-types';
 import { values } from 'lodash';
 
 import Page from 'shared/components/Page';
@@ -10,12 +10,13 @@ import balanceShape from '../../shapes/balanceShape';
 import styles from './Account.scss';
 
 export default function Account(props) {
-  const { balances, prices } = props;
+  const { claimable, balances, prices } = props;
 
   return (
     <Page className={styles.account}>
       <AccountPanel
         className={styles.panel}
+        claimable={claimable}
         balances={values(balances)}
         prices={prices}
       />
@@ -28,6 +29,7 @@ export default function Account(props) {
 }
 
 Account.propTypes = {
+  claimable: string.isRequired,
   balances: objectOf(balanceShape).isRequired,
   prices: objectOf(number).isRequired
 };

--- a/src/renderer/account/components/AccountPanel/AccountPanel.js
+++ b/src/renderer/account/components/AccountPanel/AccountPanel.js
@@ -11,7 +11,7 @@ import balanceShape from '../../shapes/balanceShape';
 import styles from './AccountPanel.scss';
 
 export default function AccountPanel(props) {
-  const { className, address, balances, prices, currency } = props;
+  const { className, address, claimable, balances, prices, currency } = props;
 
   return (
     <Panel className={classNames(styles.accountPanel, className)}>
@@ -29,6 +29,7 @@ export default function AccountPanel(props) {
       </div>
       <Holdings
         className={styles.holdings}
+        claimable={claimable}
         balances={balances}
         prices={prices}
         currency={currency}
@@ -40,6 +41,7 @@ export default function AccountPanel(props) {
 AccountPanel.propTypes = {
   className: string,
   address: string.isRequired,
+  claimable: string.isRequired,
   balances: arrayOf(balanceShape).isRequired,
   prices: objectOf(number).isRequired,
   currency: string.isRequired

--- a/src/renderer/account/components/AccountPanel/ClaimButton/ClaimButton.js
+++ b/src/renderer/account/components/AccountPanel/ClaimButton/ClaimButton.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import classNames from 'classnames';
+import { bool, string, func } from 'prop-types';
+import { noop } from 'lodash';
+
+import Button from 'shared/components/Forms/Button';
+
+import styles from './ClaimButton.scss';
+
+export default class ClaimButton extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    loading: bool,
+    amount: string.isRequired,
+    symbol: string.isRequired,
+    onClick: func
+  };
+
+  static defaultProps = {
+    className: null,
+    loading: false,
+    onClick: noop
+  };
+
+  render() {
+    const { className, loading, amount, symbol, onClick } = this.props;
+
+    return (
+      <Button
+        className={classNames(className, styles.claimButton)}
+        disabled={loading}
+        onClick={onClick}
+      >
+        Claim {amount} {symbol}
+      </Button>
+    );
+  }
+}

--- a/src/renderer/account/components/AccountPanel/ClaimButton/ClaimButton.scss
+++ b/src/renderer/account/components/AccountPanel/ClaimButton/ClaimButton.scss
@@ -1,0 +1,7 @@
+.claimButton {
+  width: 100%;
+  height: 26px;
+  background: transparent;
+  font-size: 12px;
+  font-weight: bold;
+}

--- a/src/renderer/account/components/AccountPanel/ClaimButton/index.js
+++ b/src/renderer/account/components/AccountPanel/ClaimButton/index.js
@@ -1,0 +1,36 @@
+import { compose } from 'recompose';
+import { withData, withActions, progressValues } from 'spunky';
+
+import authActions from 'login/actions/authActions';
+import claimActions from 'shared/actions/claimActions';
+import withLoadingProp from 'shared/hocs/withLoadingProp';
+import withNetworkData from 'shared/hocs/withNetworkData';
+import withProgressChange from 'shared/hocs/withProgressChange';
+import { withSuccessToast, withErrorToast } from 'shared/hocs/withToast';
+
+import ClaimButton from './ClaimButton';
+
+const { LOADED, FAILED } = progressValues;
+
+const mapAuthDataToProps = ({ address, wif }) => ({ address, wif });
+
+const mapClaimActionsToProps = (actions, props) => ({
+  onClick: () => actions.call({ net: props.net, address: props.address, wif: props.wif })
+});
+
+export default compose(
+  withNetworkData(),
+  withData(authActions, mapAuthDataToProps),
+  withActions(claimActions, mapClaimActionsToProps),
+  withLoadingProp(claimActions),
+
+  withSuccessToast(),
+  withProgressChange(claimActions, LOADED, (state, props) => {
+    props.showSuccessToast(`Claim submitted, available ${props.symbol} will update shortly`);
+  }),
+
+  withErrorToast(),
+  withProgressChange(claimActions, FAILED, (state, props) => {
+    props.showErrorToast(`Claim failed. ${state.error}`);
+  })
+)(ClaimButton);

--- a/src/renderer/account/components/AccountPanel/Holdings/Holdings.js
+++ b/src/renderer/account/components/AccountPanel/Holdings/Holdings.js
@@ -2,6 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { number, string, arrayOf, objectOf } from 'prop-types';
 
+import { GAS } from 'shared/values/assets';
+
 import TokenBalance from '../TokenBalance';
 import balanceShape from '../../../shapes/balanceShape';
 import styles from './Holdings.scss';
@@ -9,6 +11,7 @@ import styles from './Holdings.scss';
 export default class Holdings extends React.PureComponent {
   static propTypes = {
     className: string,
+    claimable: string.isRequired,
     balances: arrayOf(balanceShape).isRequired,
     prices: objectOf(number).isRequired,
     currency: string.isRequired
@@ -28,7 +31,7 @@ export default class Holdings extends React.PureComponent {
   }
 
   renderBalances = () => {
-    const { balances, prices, currency } = this.props;
+    const { claimable, balances, prices, currency } = this.props;
 
     return balances.map((token) => (
       <TokenBalance
@@ -36,6 +39,7 @@ export default class Holdings extends React.PureComponent {
         token={token}
         price={prices[token.symbol] || 0}
         currency={currency}
+        claimable={token.scriptHash === GAS ? claimable : null}
       />
     ));
   }

--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import BigNumber from 'bignumber.js';
 import classNames from 'classnames';
 import { string, number } from 'prop-types';
 
 import TokenIcon from 'shared/components/TokenIcon';
-import Button from 'shared/components/Forms/Button';
 
 import balanceShape from '../../../shapes/balanceShape';
 import formatCurrency from '../../../util/formatCurrency';
+import ClaimButton from '../ClaimButton';
 import styles from './TokenBalance.scss';
 
 export default class TokenBalance extends React.PureComponent {
@@ -54,16 +55,18 @@ export default class TokenBalance extends React.PureComponent {
   }
 
   renderClaim = () => {
-    const { claimable } = this.props;
+    const { claimable, token } = this.props;
 
-    if (!claimable) {
+    if (!claimable || new BigNumber(claimable).eq(0)) {
       return null;
     }
 
     return (
-      <Button className={styles.claim} onClick={this.handleClaim}>
-        Claim {claimable} GAS
-      </Button>
+      <ClaimButton
+        className={styles.claim}
+        amount={claimable}
+        symbol={token.symbol}
+      />
     );
   }
 
@@ -78,10 +81,5 @@ export default class TokenBalance extends React.PureComponent {
         scriptHash={token.scriptHash}
       />
     );
-  }
-
-  handleClaim = (_event) => {
-    // TODO
-    alert('TODO: claim gas here!');
   }
 }

--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { string, number } from 'prop-types';
 
 import TokenIcon from 'shared/components/TokenIcon';
+import Button from 'shared/components/Forms/Button';
 
 import balanceShape from '../../../shapes/balanceShape';
 import formatCurrency from '../../../util/formatCurrency';
@@ -13,18 +14,29 @@ export default class TokenBalance extends React.PureComponent {
     className: string,
     token: balanceShape.isRequired,
     price: number.isRequired,
-    currency: string.isRequired
+    currency: string.isRequired,
+    claimable: string
   };
 
   static defaultProps = {
-    className: null
+    className: null,
+    claimable: null
   };
 
   render = () => {
-    const { className, token, price, currency } = this.props;
+    return (
+      <div className={classNames(styles.tokenBalance, this.props.className)}>
+        {this.renderToken()}
+        {this.renderClaim()}
+      </div>
+    );
+  }
+
+  renderToken = () => {
+    const { token, price, currency } = this.props;
 
     return (
-      <div className={classNames(styles.tokenBalance, className)}>
+      <div className={styles.token}>
         {this.renderImage()}
         <div className={styles.detail}>
           <div className={styles.balance}>{token.balance} {token.symbol}</div>
@@ -41,6 +53,20 @@ export default class TokenBalance extends React.PureComponent {
     );
   }
 
+  renderClaim = () => {
+    const { claimable } = this.props;
+
+    if (!claimable) {
+      return null;
+    }
+
+    return (
+      <Button className={styles.claim} onClick={this.handleClaim}>
+        Claim {claimable} GAS
+      </Button>
+    );
+  }
+
   renderImage = () => {
     const { token } = this.props;
 
@@ -52,5 +78,10 @@ export default class TokenBalance extends React.PureComponent {
         scriptHash={token.scriptHash}
       />
     );
+  }
+
+  handleClaim = (_event) => {
+    // TODO
+    alert('TODO: claim gas here!');
   }
 }

--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.scss
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.scss
@@ -3,13 +3,13 @@
   background: #f8f9fa;
   border-radius: 4px;
 
+  &:not(:last-child) {
+    margin-bottom: 12px;
+  }
+
   .token {
     display: flex;
     align-items: center;
-
-    &:not(:last-child) {
-      margin-bottom: 12px;
-    }
 
     .icon {
       flex: 0 0 auto;
@@ -41,10 +41,6 @@
   }
 
   .claim {
-    width: 100%;
-    height: 26px;
-    background: transparent;
-    font-size: 12px;
-    font-weight: bold;
+    margin-top: 4px;
   }
 }

--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.scss
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.scss
@@ -1,39 +1,50 @@
 .tokenBalance {
-  display: flex;
-  align-items: center;
   padding: 10px;
   background: #f8f9fa;
   border-radius: 4px;
 
-  &:not(:last-child) {
-    margin-bottom: 12px;
-  }
+  .token {
+    display: flex;
+    align-items: center;
 
-  .icon {
-    flex: 0 0 auto;
-    max-width: 28px;
-    max-height: 28px;
-    margin-right: 10px;
-  }
-
-  .detail {
-    flex: 1 1 auto;
-    flex-direction: column;
-    align-items: stretch;
-
-    .balance {
-      color: #000;
-      line-height: 21px;
-      font-size: 14px;
-      font-weight: 500;
+    &:not(:last-child) {
+      margin-bottom: 12px;
     }
 
-    .currency {
-      display: flex;
-      justify-content: space-between;
-      color: #8887a5;
-      line-height: 21px;
-      font-size: 12px;
+    .icon {
+      flex: 0 0 auto;
+      max-width: 28px;
+      max-height: 28px;
+      margin-right: 10px;
     }
+
+    .detail {
+      flex: 1 1 auto;
+      flex-direction: column;
+      align-items: stretch;
+
+      .balance {
+        color: #000;
+        line-height: 21px;
+        font-size: 14px;
+        font-weight: 500;
+      }
+
+      .currency {
+        display: flex;
+        justify-content: space-between;
+        color: #8887a5;
+        line-height: 21px;
+        font-size: 12px;
+      }
+    }
+  }
+
+  .claim {
+    width: 100%;
+    height: 26px;
+    background: transparent;
+    font-size: 12px;
+    font-weight: bold;
   }
 }

--- a/src/renderer/account/components/AccountPanel/TokenBalance/index.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/index.js
@@ -1,1 +1,22 @@
-export { default } from './TokenBalance';
+import { compose } from 'recompose';
+import { withData, withActions } from 'spunky';
+
+import authActions from 'login/actions/authActions';
+import claimActions from 'shared/actions/claimableActions';
+import withLoadingProp from 'shared/hocs/withLoadingProp';
+import withNetworkData from 'shared/hocs/withNetworkData';
+
+import TokenBalance from './TokenBalance';
+
+const mapAuthDataToProps = ({ address }) => ({ address });
+
+const mapClaimActionsToProps = (actions, props) => ({
+  getBalances: () => actions.call({ net: props.net, address: props.address })
+});
+
+export default compose(
+  withNetworkData(),
+  withData(authActions, mapAuthDataToProps),
+  withActions(claimActions, mapClaimActionsToProps),
+  withLoadingProp(claimActions, { propName: 'claiming' })
+)(TokenBalance);

--- a/src/renderer/root/components/AuthenticatedLayout/index.js
+++ b/src/renderer/root/components/AuthenticatedLayout/index.js
@@ -5,6 +5,7 @@ import { isEqual } from 'lodash';
 
 import authActions from 'login/actions/authActions';
 import balancesActions from 'shared/actions/balancesActions';
+import claimableActions from 'shared/actions/claimableActions';
 import blockActions from 'shared/actions/blockActions';
 import withAuthState from 'login/hocs/withAuthState';
 import withNetworkData from 'shared/hocs/withNetworkData';
@@ -26,8 +27,12 @@ const mapBlockActionsToProps = (actions, props) => ({
   getLastBlock: () => actions.call({ net: props.currentNetwork })
 });
 
-const mapBalancesDataToProps = (actions, props) => ({
+const mapBalancesActionsToProps = (actions, props) => ({
   getBalances: () => actions.call({ net: props.currentNetwork, address: props.address })
+});
+
+const mapClaimableActionsToProps = (actions, props) => ({
+  getClaimable: () => actions.call({ net: props.currentNetwork, address: props.address })
 });
 
 const mapBlockDataToProps = (block) => ({ block });
@@ -41,11 +46,13 @@ export default compose(
   // Whenever a new block is received, notify all dApps & update account balances.
   withData(authActions, mapAuthDataToProps),
   withData(blockActions, mapBlockDataToProps),
-  withActions(balancesActions, mapBalancesDataToProps),
+  withActions(balancesActions, mapBalancesActionsToProps),
+  withActions(claimableActions, mapClaimableActionsToProps),
   withProgressChange(blockActions, LOADED, (state, props, prevProps) => {
     if (!isEqual(props.block, prevProps.block)) {
       notifyWebviews('event', 'block', props.block);
       props.getBalances();
+      props.getClaimable();
     }
   })
 )(AuthenticatedLayout);

--- a/src/renderer/shared/actions/claimActions.js
+++ b/src/renderer/shared/actions/claimActions.js
@@ -4,6 +4,4 @@ import claimGas from '../util/claimGas';
 
 export const ID = 'claim';
 
-export default createActions(ID, ({ net, address, wif }) => () => {
-  return claimGas({ net, address, wif });
-});
+export default createActions(ID, (options) => () => claimGas(options));

--- a/src/renderer/shared/actions/claimableActions.js
+++ b/src/renderer/shared/actions/claimableActions.js
@@ -1,0 +1,9 @@
+import { api, u } from '@cityofzion/neon-js';
+import { createActions } from 'spunky';
+
+export const ID = 'claimable';
+
+export default createActions(ID, ({ net, address }) => async () => {
+  const total = await api.getMaxClaimAmountFrom({ net, address }, api.neoscan);
+  return total instanceof u.Fixed8 ? total.toString() : '0';
+});

--- a/src/renderer/shared/util/claimGas.js
+++ b/src/renderer/shared/util/claimGas.js
@@ -10,7 +10,7 @@ export default async function claimGas({ net, address, wif }) {
   const { response: { result, txid } } = await api.claimGas(config, api.neoscan);
 
   if (!result) {
-    throw new Error('Claim failed.');
+    throw new Error('Transaction rejected by blockchain');
   }
 
   return txid;


### PR DESCRIPTION
## Description
This is the first iteration of adding a "Claim GAS" button to the account screen.  Currently, it simply displays the total amount of GAS that should be claimable, then claims GAS based upon what is actually unclaimed.  These amounts might not match, but it will allow whatever is tracked as unclaimed (per the last tx) to be claimed.

The next iteration will have to do the following steps:

1. update available claims by sending the user's full balance to himself
2. polling for the updated claim amount
3. claiming the gas

## Motivation and Context
Users want to be able to claim GAS.

## How Has This Been Tested?
Claiming GAS, waiting for block to update.

## Screenshots (if appropriate)
<img width="258" alt="screen shot 2018-10-17 at 11 15 51 pm" src="https://user-images.githubusercontent.com/169093/47131137-a87a1080-d262-11e8-9dc5-07ad39cdae9e.png">

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A