### PR TITLE
feat(settings): show current and latest versions

### DIFF
--- a/src/renderer/settings/actions/versionActions.js
+++ b/src/renderer/settings/actions/versionActions.js
@@ -1,0 +1,16 @@
+import fetch from 'node-fetch';
+import { createActions } from 'spunky';
+
+export const VERSION_ID = 'version';
+
+export default createActions(VERSION_ID, () => async () => {
+  const response = await fetch('https://api.github.com/repos/nos/client/releases');
+  const data = await response.json();
+  const latest = data[0];
+
+  if (!latest || !latest.tag_name) {
+    throw new Error('Unable to retrieve latest version.');
+  }
+
+  return latest.tag_name;
+});

--- a/src/renderer/settings/components/Settings/Settings.js
+++ b/src/renderer/settings/components/Settings/Settings.js
@@ -9,6 +9,7 @@ import ScrollContainer from '../ScrollContainer';
 import GeneralSettings from '../GeneralSettings';
 import NetworkSettings from '../NetworkSettings';
 import SidebarLink from '../SidebarLink';
+import Version from '../Version';
 import styles from './Settings.scss';
 
 // eslint-disable-next-line react/no-multi-comp
@@ -26,6 +27,10 @@ export default class Settings extends React.PureComponent {
     return (
       <ScrollContainer id="settingsContainer" ref={this.registerRef} className={styles.settings}>
         <Page className={styles.page}>
+          <Panel className={styles.panel}>
+            <Version className={styles.version} />
+          </Panel>
+
           <Panel className={styles.panel}>
             <div className={styles.sidebar}>
               <Sticky relative topOffset={this.state.offset}>

--- a/src/renderer/settings/components/Settings/Settings.scss
+++ b/src/renderer/settings/components/Settings/Settings.scss
@@ -10,11 +10,16 @@
   .panel {
     display: flex;
 
+    &:not(:last-child) {
+      margin-bottom: 20px;
+    }
+
     .sidebar {
       flex: 0 0 auto;
     }
 
-    .content {
+    .content,
+    .version {
       flex: 1 1 auto;
     }
   }

--- a/src/renderer/settings/components/Version/Version.js
+++ b/src/renderer/settings/components/Version/Version.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import classNames from 'classnames';
+import { bool, string, func } from 'prop-types';
+import { noop } from 'lodash';
+
+import Logo from 'shared/images/logo.svg';
+import Loading from 'shared/components/Loading';
+import PrimaryButton from 'shared/components/Forms/PrimaryButton';
+import Button from 'shared/components/Forms/Button';
+
+import styles from './Version.scss';
+
+export default class Version extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    loading: bool,
+    current: string.isRequired,
+    latest: string,
+    openTab: func
+  };
+
+  static defaultProps = {
+    className: null,
+    loading: false,
+    latest: null,
+    openTab: noop
+  };
+
+  render() {
+    return (
+      <div className={classNames(styles.version, this.props.className)}>
+        <Logo className={styles.logo} />
+        <div className={styles.current}>
+          <div className={styles.appName}>nOS Client</div>
+          Version {this.props.current}
+        </div>
+        <div className={styles.latest}>
+          {this.renderLatest()}
+          <Button className={styles.button} onClick={this.handleGithub}>
+            GitHub
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  renderLatest = () => {
+    if (this.props.loading) {
+      return this.renderLoading();
+    } else if (this.props.current === this.props.latest) {
+      return this.renderUpToDate();
+    } else {
+      return this.renderUpdate();
+    }
+  }
+
+  renderLoading = () => {
+    return <Loading className={styles.loading} />;
+  }
+
+  renderUpToDate = () => {
+    return (
+      <div className={styles.upToDate}>
+        nOS is up to date
+      </div>
+    );
+  }
+
+  renderUpdate = () => {
+    return (
+      <div className={styles.update}>
+        <div className={styles.messaging}>
+          <strong>Update Available</strong>
+          Version {this.props.latest}
+        </div>
+        <PrimaryButton className={styles.button} onClick={this.handleUpdate}>
+          Update
+        </PrimaryButton>
+      </div>
+    );
+  }
+
+  handleGithub = () => {
+    this.props.openTab('https://github.com/nos/client');
+  }
+
+  handleUpdate = () => {
+    this.props.openTab('https://github.com/nos/client/releases');
+  }
+}

--- a/src/renderer/settings/components/Version/Version.scss
+++ b/src/renderer/settings/components/Version/Version.scss
@@ -1,0 +1,60 @@
+.version {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  -webkit-font-smoothing: antialiased;
+
+  .logo {
+    flex: 0 0 auto;
+    width: 36px;
+    height: 36px;
+    margin-right: 15px;
+  }
+
+  .current {
+    flex: 1 1 auto;
+    font-size: 12px;
+    font-weight: 500;
+    color: $light-text-color;
+
+    .appName {
+      line-height: 24px;
+      font-size: 18px;
+      font-weight: normal;
+      color: #1e1b52;
+    }
+  }
+
+  .latest {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+
+    .loading,
+    .upToDate {
+      line-height: 18px;
+      font-size: 14px;
+      font-weight: 500;
+      color: $light-text-color;
+    }
+
+    .update {
+      display: flex;
+      align-items: center;
+      font-size: 12px;
+      color: $light-text-color;
+
+      strong {
+        display: block;
+        line-height: 18px;
+        font-size: 14px;
+        font-weight: 500;
+        color: $primary-text-color;
+      }
+    }
+
+    .button {
+      margin-left: 15px;
+    }
+  }
+}

--- a/src/renderer/settings/components/Version/index.js
+++ b/src/renderer/settings/components/Version/index.js
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux';
+import { compose, withProps } from 'recompose';
+import { withCall, withData } from 'spunky';
+
+import withLoadingProp from 'shared/hocs/withLoadingProp';
+import { openTab } from 'browser/actions/browserActions';
+import { EXTERNAL } from 'browser/values/browserValues';
+
+import Version from './Version';
+import versionActions from '../../actions/versionActions';
+import pkg from '../../../../../package.json';
+
+const mapVersionToProps = (version) => ({
+  latest: version
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  openTab: (target) => dispatch(openTab({ type: EXTERNAL, target }))
+});
+
+export default compose(
+  connect(null, mapDispatchToProps),
+  withProps({ current: pkg.version }),
+  withCall(versionActions),
+  withLoadingProp(versionActions),
+  withData(versionActions, mapVersionToProps)
+)(Version);

--- a/src/renderer/shared/components/Loading/Loading.js
+++ b/src/renderer/shared/components/Loading/Loading.js
@@ -1,5 +1,14 @@
 import React from 'react';
+import { string } from 'prop-types';
 
-export default function Loading() {
-  return <div>Loading...</div>;
+export default function Loading(props) {
+  return <div className={props.className}>Loading...</div>;
 }
+
+Loading.propTypes = {
+  className: string
+};
+
+Loading.defaultProps = {
+  className: null
+};


### PR DESCRIPTION
## Description
This adds the current & latest available versions of the nOS client to the settings screen.

@deanpress This will be useful to provide clarity for instructions directing users how to check if they have the latest version needed for ICO.

## Motivation and Context
The user should have an easy way to check the app version.

## How Has This Been Tested?
Opening the settings page, clicking the button links.

## Screenshots (if appropriate)
<img width="790" alt="screen shot 2018-10-24 at 7 56 05 pm" src="https://user-images.githubusercontent.com/169093/47469598-550a4400-d7c7-11e8-9738-dd65ed184fa1.png">

<img width="788" alt="screen shot 2018-10-24 at 7 56 37 pm" src="https://user-images.githubusercontent.com/169093/47469599-550a4400-d7c7-11e8-8172-8ff169032248.png">

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A