### PR TITLE
chore(copy): replace react-copy-to-clipboard with nos fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-solid-svg-icons": "5.4.1",
     "@fortawesome/react-fontawesome": "0.1.3",
     "@ledgerhq/hw-transport-node-hid": "4.18.0",
+    "@nosplatform/react-copy-to-clipboard": "5.0.1",
     "bignumber.js": "7.2.1",
     "classnames": "2.2.6",
     "connected-react-router": "4.5.0",
@@ -36,7 +37,6 @@
     "rc-tooltip": "3.7.3",
     "react": "16.5.2",
     "react-click-outside": "3.0.1",
-    "react-copy-to-clipboard": "https://github.com/nos/react-copy-to-clipboard",
     "react-dom": "16.5.2",
     "react-is": "16.5.2",
     "react-redux": "5.0.7",
@@ -63,7 +63,6 @@
     "build": "yarn build:main && yarn build:renderer",
     "build:main": "electron-webpack main",
     "build:renderer": "cross-env NODE_ENV=production webpack --config config/webpack.renderer.js",
-    "build:react-copy-to-clipboard": "cd node_modules/react-copy-to-clipboard && yarn && yarn build && cd ../..",
     "dist": "yarn run clean && yarn run build && cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=true electron-builder",
     "pack": "yarn dist --dir -c.compression=store -c.mac.identity=null",
     "pretest": "yarn run lint && yarn run stylelint",
@@ -73,7 +72,7 @@
     "lint": "eslint --env browser,node,server --ext .jsx,.js --color .",
     "lint:fix": "yarn run lint --fix",
     "clean": "rimraf build dist coverage",
-    "postinstall": "yarn build:react-copy-to-clipboard && electron-builder install-app-deps && electron-rebuild --force"
+    "postinstall": "electron-builder install-app-deps && electron-rebuild --force"
   },
   "devDependencies": {
     "babel-eslint": "10.0.1",

--- a/src/renderer/account/components/TransactionsPanel/Receive/Receive.js
+++ b/src/renderer/account/components/TransactionsPanel/Receive/Receive.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import QRCode from 'qrcode.react';
 import classNames from 'classnames';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { CopyToClipboard } from '@nosplatform/react-copy-to-clipboard';
 import { string, func } from 'prop-types';
 import { noop } from 'lodash';
 

--- a/src/renderer/register/components/AccountDetails/AccountDatum/AccountDatum.js
+++ b/src/renderer/register/components/AccountDetails/AccountDatum/AccountDatum.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { CopyToClipboard } from '@nosplatform/react-copy-to-clipboard';
 import { string, func } from 'prop-types';
 import { noop, toLower, startCase } from 'lodash';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,21 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
   integrity sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==
 
+"@nosplatform/copy-to-clipboard@^3":
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/@nosplatform/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f814dce19c1f48724c3b370621c3a93d2209bedf"
+  integrity sha512-ksnZqBwDRsb9ECk0hOEjN0JeUvUAAxGo33evl3bJsVA5FhiJd/urfccNcxcbbv4qXKFq7K5j3cVJXdfq7ufvrA==
+  dependencies:
+    toggle-selection "^1.0.3"
+
+"@nosplatform/react-copy-to-clipboard@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/@nosplatform/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#47c11efcc6d4140b4f0b54c564f758046fdccbb3"
+  integrity sha512-f2e/OJEykWvzNWMO5Nh2AAwJRHkTncFf2/g2OGK00TRRI7haR1hr4dhq9FOpyjFrKlF6mA02/fxm/iz62agd7Q==
+  dependencies:
+    "@nosplatform/copy-to-clipboard" "^3"
+    prop-types "^15.5.8"
+
 "@types/node@*":
   version "10.3.3"
   resolved "https://registry.npmjs.org/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
@@ -2712,12 +2727,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-
-"copy-to-clipboard@https://github.com/nos/copy-to-clipboard":
-  version "3.0.8"
-  resolved "https://github.com/nos/copy-to-clipboard#36317d449d4c536e9f795ac65fb7bd0b475fe3bb"
-  dependencies:
-    toggle-selection "^1.0.3"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -9963,13 +9972,6 @@ react-click-outside@3.0.1:
   integrity sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==
   dependencies:
     hoist-non-react-statics "^2.1.1"
-
-"react-copy-to-clipboard@https://github.com/nos/react-copy-to-clipboard":
-  version "5.0.1"
-  resolved "https://github.com/nos/react-copy-to-clipboard#0e45b9fba0542dd5db72b12e07769bbc66129e9d"
-  dependencies:
-    copy-to-clipboard "https://github.com/nos/copy-to-clipboard"
-    prop-types "^15.5.8"
 
 react-dom@16.5.2:
   version "16.5.2"


### PR DESCRIPTION
## Description
This updates the react-copy-to-clipboard dependency to an nos published fork.

## Motivation and Context
Building the dependency from GitHub wasn't working properly for Windows. 👊

## How Has This Been Tested?
Copying account details from registration screen.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A