### PR TITLE
chore(version): fix svg flicker on settings screen load

### DIFF
--- a/src/renderer/settings/components/Version/Version.js
+++ b/src/renderer/settings/components/Version/Version.js
@@ -29,7 +29,7 @@ export default class Version extends React.PureComponent {
   render() {
     return (
       <div className={classNames(styles.version, this.props.className)}>
-        <Logo className={styles.logo} />
+        <Logo className={styles.logo} width="36" height="36" />
         <div className={styles.current}>
           <div className={styles.appName}>nOS Client</div>
           Version {this.props.current}


### PR DESCRIPTION
## Description
Fixes an SVG size flicker when the settings screen loads for the first time.

## Motivation and Context
Jarring experience.

## How Has This Been Tested?
Loading the settings screen.

## Screenshots (if appropriate)
https://gyazo.com/1b98aa48b3a2ca6dfc1d4f9912b45d40

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A