### PR TITLE
feat(account): breakdown chart improvements

### DIFF
--- a/src/renderer/account/components/AccountPanel/AccountPanel.scss
+++ b/src/renderer/account/components/AccountPanel/AccountPanel.scss
@@ -12,8 +12,6 @@
 
     .breakdown {
       flex: 1 1 auto;
-      min-height: 400px;
-      height: 100%;
     }
 
     .address {

--- a/src/renderer/account/components/AccountPanel/AccountPanel.scss
+++ b/src/renderer/account/components/AccountPanel/AccountPanel.scss
@@ -12,7 +12,7 @@
 
     .breakdown {
       flex: 1 1 auto;
-      min-height: 300px;
+      min-height: 400px;
     }
 
     .address {

--- a/src/renderer/account/components/AccountPanel/AccountPanel.scss
+++ b/src/renderer/account/components/AccountPanel/AccountPanel.scss
@@ -13,6 +13,7 @@
     .breakdown {
       flex: 1 1 auto;
       min-height: 400px;
+      height: 100%;
     }
 
     .address {

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
@@ -5,6 +5,7 @@ import { number, string, arrayOf, objectOf } from 'prop-types';
 import TokenIcon from 'shared/components/TokenIcon';
 
 import balanceShape from '../../../shapes/balanceShape';
+import TotalValue from './TotalValue';
 import BreakdownChart from './BreakdownChart';
 import styles from './Breakdown.scss';
 
@@ -25,13 +26,20 @@ export default class Breakdown extends React.PureComponent {
 
     return (
       <div className={classNames(styles.breakdown, className)}>
-        <BreakdownChart
-          className={styles.chart}
+        <TotalValue
+          className={styles.totalValue}
           balances={balances}
           prices={prices}
           currency={currency}
         />
-        {this.renderIcon()}
+        <div className={styles.chart}>
+          <BreakdownChart
+            balances={balances}
+            prices={prices}
+            currency={currency}
+          />
+          {this.renderIcon()}
+        </div>
       </div>
     );
   }

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
@@ -1,25 +1,18 @@
 import React from 'react';
 import classNames from 'classnames';
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Label } from 'recharts';
-import { string } from 'prop-types';
-import { times, reduce } from 'lodash';
+import { number, string, arrayOf, objectOf } from 'prop-types';
 
-import formatCurrency from 'account/util/formatCurrency';
+import TokenIcon from 'shared/components/TokenIcon';
 
-import SectionLabel from './SectionLabel';
-import chartDataShape from '../../../shapes/chartDataShape';
+import balanceShape from '../../../shapes/balanceShape';
+import BreakdownChart from './BreakdownChart';
 import styles from './Breakdown.scss';
-
-const COLORS = ['#5ebb46', '#b5d433', '#0b99e3'];
-
-function reduceSum(data) {
-  return reduce(data, (sum, datum) => sum + datum.value, 0);
-}
 
 export default class Breakdown extends React.PureComponent {
   static propTypes = {
     className: string,
-    data: chartDataShape.isRequired,
+    balances: arrayOf(balanceShape).isRequired,
+    prices: objectOf(number).isRequired,
     currency: string.isRequired
   };
 
@@ -28,61 +21,28 @@ export default class Breakdown extends React.PureComponent {
   };
 
   render() {
-    const data = this.getData();
+    const { className, balances, prices, currency } = this.props;
 
     return (
-      <ResponsiveContainer width="100%" className={classNames(styles.breakdown, this.props.className)}>
-        <PieChart>
-          <Pie
-            data={data}
-            dataKey="value"
-            nameKey="label"
-            innerRadius="50%"
-            outerRadius="65%"
-            startAngle={90}
-            endAngle={-270}
-            label={SectionLabel}
-            labelLine={false}
-            isAnimationActive={false}
-          >
-            {times(data.length, (index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={COLORS[index % COLORS.length]}
-                stroke={COLORS[index]}
-              />
-            ))}
-            <Label
-              id="totalValue"
-              position="center"
-              fontSize={28}
-              value={this.getTotalValue()}
-            />
-          </Pie>
-          <Tooltip formatter={this.formatValue} />
-        </PieChart>
-      </ResponsiveContainer>
+      <div className={classNames(styles.breakdown, className)}>
+        <BreakdownChart
+          className={styles.chart}
+          balances={balances}
+          prices={prices}
+          currency={currency}
+        />
+        {this.renderIcon()}
+      </div>
     );
   }
 
-  getData = () => {
-    const data = [...this.props.data];
+  renderIcon = () => {
+    const token = this.props.balances[0];
 
-    if (data.length <= 3) {
-      return data;
+    if (!token) {
+      return null;
     }
 
-    return [
-      ...data.splice(0, 2),
-      { label: 'OTHERS', value: reduceSum(data) }
-    ];
-  }
-
-  getTotalValue = () => {
-    return this.formatValue(reduceSum(this.props.data));
-  }
-
-  formatValue = (value) => {
-    return formatCurrency(value, this.props.currency);
+    return <TokenIcon className={styles.icon} {...token} />;
   }
 }

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.js
@@ -38,7 +38,7 @@ export default class Breakdown extends React.PureComponent {
             dataKey="value"
             nameKey="label"
             innerRadius="50%"
-            outerRadius="80%"
+            outerRadius="65%"
             startAngle={90}
             endAngle={-270}
             label={SectionLabel}

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.scss
@@ -1,11 +1,12 @@
 .breakdown {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  position: relative;
 
-  text {
-    fill: #494759;
-    font-family: $primary-font-stack;
+  .icon {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 25%;
+    height: 25%;
+    transform: translate(-50%, -50%);
   }
 }

--- a/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/Breakdown.scss
@@ -1,12 +1,23 @@
 .breakdown {
-  position: relative;
+  display: flex;
+  flex-direction: column;
 
-  .icon {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    width: 25%;
-    height: 25%;
-    transform: translate(-50%, -50%);
+  .totalValue {
+    flex: 0 0 auto;
+    margin: 20px;
+  }
+
+  .chart {
+    flex: 1 1 100%;
+    position: relative;
+
+    .icon {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 25%;
+      height: 25%;
+      transform: translate(-50%, -50%);
+    }
   }
 }

--- a/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import classNames from 'classnames';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Label } from 'recharts';
+import { string } from 'prop-types';
+import { times, reduce } from 'lodash';
+
+import formatCurrency from 'account/util/formatCurrency';
+
+import SectionLabel from '../SectionLabel';
+import chartDataShape from '../../../../shapes/chartDataShape';
+import styles from './BreakdownChart.scss';
+
+const COLORS = ['#5ebb46', '#b5d433', '#0b99e3'];
+
+function reduceSum(data) {
+  return reduce(data, (sum, datum) => sum + datum.value, 0);
+}
+
+export default class BreakdownChart extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    data: chartDataShape.isRequired,
+    currency: string.isRequired
+  };
+
+  static defaultProps = {
+    className: null
+  };
+
+  render() {
+    const data = this.getData();
+
+    return (
+      <ResponsiveContainer width="100%" className={classNames(styles.breakdownChart, this.props.className)}>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="symbol"
+            innerRadius="50%"
+            outerRadius="65%"
+            startAngle={90}
+            endAngle={-270}
+            label={SectionLabel}
+            labelLine={false}
+            isAnimationActive={false}
+          >
+            {times(data.length, (index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+                stroke={COLORS[index]}
+              />
+            ))}
+            <Label
+              id="totalValue"
+              position="center"
+              fontSize={28}
+              value={this.getTotalValue()}
+            />
+          </Pie>
+          <Tooltip formatter={this.formatValue} />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  getData = () => {
+    const data = [...this.props.data];
+
+    if (data.length <= 3) {
+      return data;
+    }
+
+    return [
+      ...data.splice(0, 2),
+      { symbol: 'OTHERS', value: reduceSum(data) }
+    ];
+  }
+
+  getTotalValue = () => {
+    return this.formatValue(reduceSum(this.props.data));
+  }
+
+  formatValue = (value) => {
+    return formatCurrency(value, this.props.currency);
+  }
+}

--- a/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Label } from 'recharts';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
 import { string } from 'prop-types';
 import { times, reduce } from 'lodash';
 
@@ -52,12 +52,6 @@ export default class BreakdownChart extends React.PureComponent {
                 stroke={COLORS[index]}
               />
             ))}
-            <Label
-              id="totalValue"
-              position="center"
-              fontSize={28}
-              value={this.getTotalValue()}
-            />
           </Pie>
           <Tooltip formatter={this.formatValue} />
         </PieChart>
@@ -76,10 +70,6 @@ export default class BreakdownChart extends React.PureComponent {
       ...data.splice(0, 2),
       { symbol: 'OTHERS', value: reduceSum(data) }
     ];
-  }
-
-  getTotalValue = () => {
-    return this.formatValue(reduceSum(this.props.data));
   }
 
   formatValue = (value) => {

--- a/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.scss
@@ -4,6 +4,7 @@
   justify-content: center;
   text-align: center;
   position: relative;
+  min-height: 400px;
 
   text {
     fill: #494759;

--- a/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/BreakdownChart.scss
@@ -1,0 +1,12 @@
+.breakdownChart {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  position: relative;
+
+  text {
+    fill: #494759;
+    font-family: $primary-font-stack;
+  }
+}

--- a/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/index.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/BreakdownChart/index.js
@@ -1,0 +1,16 @@
+import { withProps } from 'recompose';
+import { map } from 'lodash';
+
+import BreakdownChart from './BreakdownChart';
+import calculateTokenValue from '../../../../util/calculateTokenValue';
+
+const calculateTokenValues = ({ balances, prices }) => map(balances, (token) => ({
+  label: token.symbol,
+  value: calculateTokenValue(token, prices)
+}));
+
+const mapBalancesToProps = (props) => ({
+  data: calculateTokenValues(props)
+});
+
+export default withProps(mapBalancesToProps)(BreakdownChart);

--- a/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.js
@@ -18,11 +18,11 @@ export default function SectionLabel(props) {
 
   return (
     <g className={styles.sectionLabel}>
-      <text x={x} y={y - 10} className={styles.label} textAnchor="start" dominantBaseline="central">
-        {label}
-      </text>
-      <text x={x} y={y + 10} className={styles.percent} textAnchor="start" dominantBaseline="central">
+      <text x={x} y={y - 10} className={styles.percent} textAnchor="start" dominantBaseline="central">
         {`${(percent * 100).toFixed(0)}%`}
+      </text>
+      <text x={x} y={y + 10} className={styles.label} textAnchor="start" dominantBaseline="central">
+        {label}
       </text>
     </g>
   );

--- a/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.js
@@ -1,14 +1,10 @@
 import React from 'react';
-import { number, string, shape } from 'prop-types';
+import { number } from 'prop-types';
 
+import chartDataShape from '../../../../shapes/chartDataShape';
 import styles from './SectionLabel.scss';
 
 const RADIAN = Math.PI / 180;
-
-const payloadShape = shape({
-  label: string.isRequired,
-  value: number.isRequired
-});
 
 export default function SectionLabel(props) {
   const { cx, cy, midAngle, outerRadius, percent, payload: { label } } = props;
@@ -34,5 +30,5 @@ SectionLabel.propTypes = {
   midAngle: number.isRequired,
   outerRadius: number.isRequired,
   percent: number.isRequired,
-  payload: payloadShape.isRequired
+  payload: chartDataShape.isRequired
 };

--- a/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/SectionLabel/SectionLabel.scss
@@ -1,14 +1,14 @@
 .sectionLabel {
   .label {
-    fill: #000;
-    font-size: 18px;
-    font-weight: 500;
-  }
-
-  .percent {
     fill: $light-text-color;
     font-size: 16px;
     font-weight: 500;
     text-transform: uppercase;
+  }
+
+  .percent {
+    fill: #000;
+    font-size: 18px;
+    font-weight: 500;
   }
 }

--- a/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/TotalValue.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/TotalValue.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import classNames from 'classnames';
+import { number, string } from 'prop-types';
+
+import formatCurrency from '../../../../util/formatCurrency';
+import styles from './TotalValue.scss';
+
+export default class TotalValue extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    total: number.isRequired,
+    currency: string.isRequired
+  };
+
+  static defaultProps = {
+    className: null
+  };
+
+  render() {
+    const { className, total, currency } = this.props;
+
+    return (
+      <div className={classNames(styles.totalValue, className)}>
+        <div className={styles.value}>{formatCurrency(total, currency)}</div>
+        <div className={styles.label}>Total Value</div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/TotalValue.scss
+++ b/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/TotalValue.scss
@@ -1,0 +1,16 @@
+.totalValue {
+  text-align: center;
+  -webkit-font-smoothing: antialiased;
+
+  .value {
+    font-size: 28px;
+    color: $primary-text-color;
+  }
+
+  .label {
+    line-height: 18px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #9A99A5;
+  }
+}

--- a/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/index.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/TotalValue/index.js
@@ -1,0 +1,13 @@
+import { withProps } from 'recompose';
+import { reduce } from 'lodash';
+
+import TotalValue from './TotalValue';
+import calculateTokenValue from '../../../../util/calculateTokenValue';
+
+const mapTotalToProps = (props) => ({
+  total: reduce(props.balances, (sum, token) => {
+    return sum + calculateTokenValue(token, props.prices);
+  }, 0.0)
+});
+
+export default withProps(mapTotalToProps)(TotalValue);

--- a/src/renderer/account/components/AccountPanel/Breakdown/index.js
+++ b/src/renderer/account/components/AccountPanel/Breakdown/index.js
@@ -1,20 +1,11 @@
-import BigNumber from 'bignumber.js';
-import { mapProps } from 'recompose';
-import { map, omit, orderBy } from 'lodash';
+import { withProps } from 'recompose';
+import { sortBy } from 'lodash';
 
 import Breakdown from './Breakdown';
+import calculateTokenValue from '../../../util/calculateTokenValue';
 
-const calculateTokenValues = ({ balances, prices }) => map(balances, (token) => ({
-  label: token.symbol,
-  value: parseFloat(
-    new BigNumber(token.balance).times(prices[token.symbol] || 0).toFixed(token.decimals),
-    10
-  )
-}));
-
-const mapBalancesToProps = (props) => ({
-  ...omit(props, 'balances'),
-  data: orderBy(calculateTokenValues(props), ['value'], ['desc'])
+const mapSortedBalances = (props) => ({
+  balances: sortBy(props.balances, (token) => -calculateTokenValue(token, props.prices))
 });
 
-export default mapProps(mapBalancesToProps)(Breakdown);
+export default withProps(mapSortedBalances)(Breakdown);

--- a/src/renderer/account/util/calculateTokenValue.js
+++ b/src/renderer/account/util/calculateTokenValue.js
@@ -1,0 +1,8 @@
+import BigNumber from 'bignumber.js';
+
+export default function calculateTokenValue(token, prices) {
+  const { symbol, balance, decimals } = token;
+  const value = new BigNumber(balance).times(prices[symbol] || 0);
+
+  return parseFloat(value.toFixed(decimals), 10);
+}


### PR DESCRIPTION
## Description
This improves the breakdown chart in a few ways:

* Prevents the labels from being cut off around edges of chart
* Renders "primary holding" token icon in middle of chart
* Moves "total value" above chart

## Motivation and Context
There have been some complaints about the chart, and we've had improved designs for awhile.  This gets us closer.

## How Has This Been Tested?
Opening the account screen for various accounts.

## Screenshots (if appropriate)
<img width="707" alt="screen shot 2018-10-28 at 12 52 36 pm" src="https://user-images.githubusercontent.com/169093/47619785-5e89f980-dab0-11e8-9471-df556ff2006b.png">

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
Fixes #409