### PR TITLE
chore(ux): restore mouse cursors throughout app

### DIFF
--- a/src/common/stylesheets/mixins.scss
+++ b/src/common/stylesheets/mixins.scss
@@ -10,11 +10,12 @@
   padding: 8px 0;
   color: $link-color;
   text-decoration: none;
-  cursor: default;
+  cursor: pointer;
   transition: all 0.2s ease;
 
   &.disabled {
     color: lighten($link-color, 20%);
+    cursor: not-allowed;
   }
 
   &:not(.disabled):focus,

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.js
@@ -79,7 +79,7 @@ export default class AddressBar extends React.PureComponent {
         />
 
         <div className={styles.buttonGroup}>
-          <NotificationsIcon className={buttonClass} />
+          <NotificationsIcon className={classNames(buttonClass, { [styles.disabled]: true })} />
         </div>
       </div>
     );

--- a/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AddressBar/AddressBar.scss
@@ -1,10 +1,12 @@
 @mixin button($color) {
   color: $color;
   stroke: currentColor;
+  cursor: pointer;
   transition: color 0.15s ease;
 
   &.disabled {
     color: lighten($color, 20%);
+    cursor: not-allowed;
   }
 
   &:not(.disabled):focus,

--- a/src/renderer/root/stylesheets/global.scss
+++ b/src/renderer/root/stylesheets/global.scss
@@ -11,8 +11,6 @@ body {
   padding: 0;
   background: $content-bg-color;
   color: #58585a;
-  user-select: none;
-  cursor: default;
 
   font: {
     family: $primary-font-stack;

--- a/src/renderer/shared/components/Forms/Button/Button.scss
+++ b/src/renderer/shared/components/Forms/Button/Button.scss
@@ -10,7 +10,7 @@
   font-size: 14px;
   text-align: center;
   box-shadow: inset 0 0 0 2px rgba(#8bc83c, 0.9);
-  cursor: default;
+  cursor: pointer;
   -webkit-font-smoothing: antialiased;
   transition: all 0.2s ease;
 

--- a/src/renderer/shared/components/Forms/Select/Select.scss
+++ b/src/renderer/shared/components/Forms/Select/Select.scss
@@ -4,6 +4,7 @@
 
   position: relative;
   width: 100%;
+  cursor: pointer;
 
   .input {
     display: flex;
@@ -29,10 +30,14 @@
     }
   }
 
-  &.disabled .input {
-    background: $disabled-background;
-    color: $disabled-color;
-    box-shadow: none;
+  &.disabled {
+    cursor: not-allowed;
+
+    .input {
+      background: $disabled-background;
+      color: $disabled-color;
+      box-shadow: none;
+    }
   }
 
   .caret {
@@ -89,6 +94,7 @@
     .item {
       color: #494759;
       font-size: 14px;
+      cursor: pointer;
 
       &.focus {
         background: rgba(#edeef2, 0.5);

--- a/src/renderer/shared/components/Tabs/Tabs.scss
+++ b/src/renderer/shared/components/Tabs/Tabs.scss
@@ -8,7 +8,7 @@
 
     .tab {
       display: block;
-      cursor: default;
+      cursor: pointer;
       -webkit-font-smoothing: antialiased;
     }
 


### PR DESCRIPTION
## Description
Restores the mouse cursor to the "pointer" style on buttons and form elements throughout the app.

## Motivation and Context
It can be hard to determine if the user has the cursor over clickable elements in some instances.

## How Has This Been Tested?
Navigating throughout the app and hovering the mouse over things.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A