### PR TITLE
chore(menu): fixed Inspect Element not displaying in prod

### DIFF
--- a/src/renderer/browser/util/bindContextMenu.js
+++ b/src/renderer/browser/util/bindContextMenu.js
@@ -34,6 +34,10 @@ function bindOnce(emitter, event, callback) {
 
 export default function bindContextMenu(browserWindowOrWebview) {
   bindOnce(browserWindowOrWebview, 'dom-ready', () => {
-    contextMenu({ window: browserWindowOrWebview, prepend });
+    contextMenu({
+      window: browserWindowOrWebview,
+      showInspectElement: true,
+      prepend
+    });
   });
 }


### PR DESCRIPTION
## Description
Fixes the "Inspect Element" context menu option in the nOS distributable.

## Motivation and Context
The menu option was only rendering in development.  To force it in production, the value must be explicitly set to true.

## How Has This Been Tested?
Running `yarn dist`, opening the executable, and right clicking on a website.

## Screenshots (if appropriate)
<img width="159" alt="screen shot 2018-10-28 at 8 43 02 pm" src="https://user-images.githubusercontent.com/169093/47625299-46d36500-daf2-11e8-9bf2-dffbf6f41092.png">

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A