### PR TITLE
chore(block): change polling frequency from 10 to 14 sec

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.js
@@ -13,7 +13,7 @@ import Navigation from './Navigation';
 import AddressBar from './AddressBar';
 import styles from './AuthenticatedLayout.scss';
 
-const POLL_FREQUENCY = 10000; // 10 seconds
+const POLL_FREQUENCY = 14000; // milliseconds
 
 export default class AuthenticatedLayout extends React.PureComponent {
   static propTypes = {


### PR DESCRIPTION
## Description
Changes polling frequency from 10 sec to 14 sec.

## Motivation and Context
There's no reason to poll every 10 seconds since block time is at ~15 seconds.  By polling one sec less often than that, we should typically see each new block come in with minimal impact.

## How Has This Been Tested?
Running the client and observing console + current block in sidebar nav.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A