### PR TITLE
feat(balance): sort nos token first

### DIFF
--- a/src/renderer/account/components/Account/index.js
+++ b/src/renderer/account/components/Account/index.js
@@ -10,7 +10,7 @@ import currencyActions from 'settings/actions/currencyActions';
 import authActions from 'login/actions/authActions';
 import withInitialCall from 'shared/hocs/withInitialCall';
 import withNetworkData from 'shared/hocs/withNetworkData';
-import { ASSETS } from 'shared/values/assets';
+import { ASSETS, NOS } from 'shared/values/assets';
 
 import Account from './Account';
 import pricesActions from '../../actions/pricesActions';
@@ -23,7 +23,7 @@ const mapCurrencyDataToProps = (currency) => ({ currency });
 
 const mapBalancesDataToProps = (balances) => ({
   balances: pickBy(balances, ({ scriptHash, balance }) => {
-    return keys(ASSETS).includes(scriptHash) || balance !== '0';
+    return keys(ASSETS).includes(scriptHash) || scriptHash === NOS || balance !== '0';
   })
 });
 

--- a/src/renderer/account/components/AccountPanel/Holdings/index.js
+++ b/src/renderer/account/components/AccountPanel/Holdings/index.js
@@ -1,1 +1,28 @@
-export { default } from './Holdings';
+import { withProps } from 'recompose';
+import { sortBy } from 'lodash';
+
+import { NOS, NEO, GAS } from 'shared/values/assets';
+
+import Holdings from './Holdings';
+
+/**
+ * Sort by:
+ * 1. preferred tokens
+ * 2. token symbol (ascending)
+ */
+const customSort = (balances, preferredOrder) => {
+  return sortBy(balances, (token) => {
+    const precidence = preferredOrder.findIndex((v) => v === token.scriptHash);
+
+    return [
+      precidence < 0 ? Infinity : precidence,
+      token.symbol
+    ];
+  });
+};
+
+const sortBalances = ({ balances }) => ({
+  balances: customSort(balances, [NOS, NEO, GAS])
+});
+
+export default withProps(sortBalances)(Holdings);

--- a/src/renderer/shared/values/assets.js
+++ b/src/renderer/shared/values/assets.js
@@ -1,3 +1,4 @@
+export const NOS = 'c9c0fc5a2b66a29d6b14601e752e6e1a445e088d';
 export const NEO = 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b';
 export const GAS = '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7';
 


### PR DESCRIPTION
## Description
Ensures that NOS token is always displayed, even if it's 0 balance, and sorts it to the top of the list.

## Motivation and Context
To provide users a way of understanding that NOS exists as a token.

## How Has This Been Tested?
Viewing an account screen for an account with zero balance.

## Screenshots (if appropriate)
![screen shot 2018-10-30 at 11 58 53 am](https://user-images.githubusercontent.com/169093/47735789-337fe100-dc3b-11e8-944d-338efd8f5064.png)

## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A