### PR TITLE
chore(balance): fix token icon centering

### DIFF
--- a/src/renderer/account/components/AccountPanel/AccountPanel.scss
+++ b/src/renderer/account/components/AccountPanel/AccountPanel.scss
@@ -3,6 +3,7 @@
   $border-width: 1px;
 
   display: flex;
+  align-items: flex-start;
 
   .summary {
     flex: 1 1 auto;


### PR DESCRIPTION
## Description
Fixed centering for the primary holding token icon.

## Motivation and Context
It's overlapping things when the user has many tokens.

## How Has This Been Tested?
Opening the account screen for an account with many tokens, resized the window.

## Screenshots (if appropriate)
![screen shot 2018-10-30 at 12 07 49 pm](https://user-images.githubusercontent.com/169093/47736402-a178d800-dc3c-11e8-9789-cb3e277151bb.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A