### PR TITLE
chore(account): localize token balances in holdings

### DIFF
--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
@@ -40,7 +40,9 @@ export default class TokenBalance extends React.PureComponent {
       <div className={styles.token}>
         {this.renderImage()}
         <div className={styles.detail}>
-          <div className={styles.balance}>{token.balance} {token.symbol}</div>
+          <div className={styles.balance}>
+            {new BigNumber(token.balance).toFormat(token.decimals)} {token.symbol}
+          </div>
           <div className={styles.currency}>
             <span className={styles.tokenValue}>
               {formatCurrency(price, currency)}


### PR DESCRIPTION
## Description
Localizes the token amount for the user.

## Motivation and Context
It can be difficult to scan/parse the token holding amount due to lack of commas (or whatever your locale uses).

## How Has This Been Tested?
Looking at the holdings.

## Screenshots (if appropriate)
![screen shot 2018-10-30 at 12 13 42 pm](https://user-images.githubusercontent.com/169093/47736836-88bcf200-dc3d-11e8-9390-e62e3d3d4ee8.png)

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A