### PR TITLE
chore(account): strip trailing zeroes from balances

### DIFF
--- a/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
+++ b/src/renderer/account/components/AccountPanel/TokenBalance/TokenBalance.js
@@ -7,6 +7,7 @@ import TokenIcon from 'shared/components/TokenIcon';
 
 import balanceShape from '../../../shapes/balanceShape';
 import formatCurrency from '../../../util/formatCurrency';
+import formatBalance from '../../../util/formatBalance';
 import ClaimButton from '../ClaimButton';
 import styles from './TokenBalance.scss';
 
@@ -41,7 +42,7 @@ export default class TokenBalance extends React.PureComponent {
         {this.renderImage()}
         <div className={styles.detail}>
           <div className={styles.balance}>
-            {new BigNumber(token.balance).toFormat(token.decimals)} {token.symbol}
+            {formatBalance(token.balance, token.decimals)} {token.symbol}
           </div>
           <div className={styles.currency}>
             <span className={styles.tokenValue}>

--- a/src/renderer/account/util/formatBalance.js
+++ b/src/renderer/account/util/formatBalance.js
@@ -1,0 +1,11 @@
+import BigNumber from 'bignumber.js';
+
+export default function formatBalance(balance, decimals) {
+  const value = new BigNumber(balance).toFormat(decimals);
+  const [integer, fraction] = value.split('.');
+
+  return [
+    integer,
+    `.${fraction || 0}`.replace(/\.?0+$/, '')
+  ].join('');
+}


### PR DESCRIPTION
## Description
This strips trailing zeroes from token balances.

## Motivation and Context
It's hard to parse balances when there are a lot of unnecessary decimal places.

## How Has This Been Tested?
Opening the account screen for an account with many balances.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A