### PR TITLE
chore(rpc): node selection for sendAsset and doInvoke

### DIFF
--- a/__tests__/renderer/browser/components/RequestsProcessor/Send/index.test.js
+++ b/__tests__/renderer/browser/components/RequestsProcessor/Send/index.test.js
@@ -56,7 +56,18 @@ describe('<Send />', () => {
     return { response: { result: false } };
   });
 
-  const sendActions = makeSendActions(sessionId, requestId, mockGetBalance, mockSendAsset);
+  const mockInvoke = jest.fn(() => ({ response: { result: false } }));
+
+  const mockGetRPCEndpoint = jest.fn((_net) => Promise.resolve('https://seed1.neo.org:443'));
+
+  const sendActions = makeSendActions(
+    sessionId,
+    requestId,
+    mockGetBalance,
+    mockSendAsset,
+    mockInvoke,
+    mockGetRPCEndpoint
+  );
   const Send = makeSend(sendActions);
 
   let callSpy;

--- a/src/renderer/browser/actions/makeInvokeActions.js
+++ b/src/renderer/browser/actions/makeInvokeActions.js
@@ -2,6 +2,8 @@ import { createActions } from 'spunky';
 import { wallet, api } from '@cityofzion/neon-js';
 import { mapKeys } from 'lodash';
 
+import getRPCEndpoint from 'util/getRPCEndpoint';
+
 import createScript from 'shared/util/createScript';
 import formatAssets from 'shared/util/formatAssets';
 import { ASSETS } from 'shared/values/assets';
@@ -26,8 +28,10 @@ async function doInvoke({
 }) {
   validateInvokeArgs({ scriptHash, operation, args, assets });
 
+  const url = await getRPCEndpoint(net);
   const config = {
     net,
+    url,
     address,
     script: createScript(scriptHash, operation, args, encodeArgs),
     privateKey: wif,

--- a/src/renderer/browser/actions/makeSendActions.js
+++ b/src/renderer/browser/actions/makeSendActions.js
@@ -6,7 +6,7 @@ import generateDAppActionId from './generateDAppActionId';
 
 export const ID = 'send';
 
-export default function makeSendActions(sessionId, requestId, getBalance, call) {
+export default function makeSendActions(sessionId, requestId, ...args) {
   const id = generateDAppActionId(sessionId, `${ID}-${requestId}`);
-  return createActions(id, (options) => () => sendAsset(options, getBalance, call));
+  return createActions(id, (options) => () => sendAsset(options, ...args));
 }

--- a/src/renderer/shared/util/claimGas.js
+++ b/src/renderer/shared/util/claimGas.js
@@ -2,6 +2,8 @@ import BigNumber from 'bignumber.js';
 import { api, wallet } from '@cityofzion/neon-js';
 import { map, reduce } from 'lodash';
 
+import getRPCEndpoint from 'util/getRPCEndpoint';
+
 import poll from './poll';
 
 const POLL_ATTEMPTS = 30;
@@ -31,8 +33,11 @@ async function getClaimableAmount({ net, address }) {
 async function updateClaimableAmount({
   net, balance, address, publicKey, privateKey, signingFunction
 }) {
+  const url = await getRPCEndpoint(net);
+
   const { response: { result } } = await api.sendAsset({
     net,
+    url,
     address,
     publicKey,
     privateKey,

--- a/src/renderer/shared/util/sendAsset.js
+++ b/src/renderer/shared/util/sendAsset.js
@@ -12,7 +12,8 @@ export default async function sendAsset(
   { net, asset, amount, receiver, address, wif, publicKey, signingFunction, remark, fee = 0 },
   getBalance = api.neoscan.getBalance,
   doSendAsset = api.sendAsset,
-  doInvoke = api.doInvoke
+  doInvoke = api.doInvoke,
+  doGetRPCEndpoint = getRPCEndpoint
 ) {
   if (!wallet.isAddress(receiver)) {
     throw new Error(`Invalid script hash: "${receiver}"`);
@@ -27,7 +28,7 @@ export default async function sendAsset(
   }
 
   const send = async () => {
-    const url = await getRPCEndpoint(net);
+    const url = await doGetRPCEndpoint(net);
     const config = { net, url, address, privateKey: wif, publicKey, signingFunction, fees: fee };
 
     if (keys(ASSETS).includes(asset)) {

--- a/src/renderer/shared/util/sendAsset.js
+++ b/src/renderer/shared/util/sendAsset.js
@@ -1,6 +1,8 @@
 import { api, wallet, u, tx } from '@cityofzion/neon-js';
 import { keys } from 'lodash';
 
+import getRPCEndpoint from 'util/getRPCEndpoint';
+
 import createScript from 'shared/util/createScript';
 import validateRemark from 'shared/util/validateRemark';
 
@@ -25,7 +27,8 @@ export default async function sendAsset(
   }
 
   const send = async () => {
-    const config = { net, address, privateKey: wif, publicKey, signingFunction, fees: fee };
+    const url = await getRPCEndpoint(net);
+    const config = { net, url, address, privateKey: wif, publicKey, signingFunction, fees: fee };
 
     if (keys(ASSETS).includes(asset)) {
       const selectedAsset = ASSETS[asset].symbol;


### PR DESCRIPTION
## Description
This adds the same NEO RPC node selection logic to sendAsset and doInvoke calls.

## Motivation and Context
This was intended to be used for all RPC calls, but some were missed due to different scenarios in logic.

## How Has This Been Tested?
It hasn't yet.  We'll need to send assets and invoke to ensure things still work properly.

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A