### PR TITLE
chore(layout): prevent window scrolling

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/Navigation/Navigation.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  overflow: hidden;
 
   ul {
     flex: 0 0 auto;


### PR DESCRIPTION
## Description
This prevents the window from scrolling when it's too short.

## Motivation and Context
This was happening when the navigation icons in the sidebar extend beyond the window height.

## How Has This Been Tested?
Shrinking the window & trying to scroll.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A