### PR TITLE
chore(deps): revert electron-is-dev upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "connected-react-router": "5.0.1",
     "ejs": "2.6.1",
     "electron-context-menu": "0.10.1",
-    "electron-is-dev": "1.0.1",
+    "electron-is-dev": "0.3.0",
     "electron-json-storage": "4.1.5",
     "electron-localshortcut": "3.1.0",
     "es6-promisify": "6.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
       "allowedVersions": "< 4"
     },
     {
+      "packageNames": ["electron-is-dev"],
+      "allowedVersions": "< 1"
+    },
+    {
       "packageNames": ["electron-webpack"],
       "allowedVersions": "< 2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,7 +3623,12 @@ electron-is-accelerator@^0.1.0:
   resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
   integrity sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns=
 
-electron-is-dev@1.0.1, electron-is-dev@^1.0.1:
+electron-is-dev@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
+  integrity sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4=
+
+electron-is-dev@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.0.1.tgz#6e0a184736fe7aea77d18210b0b0f6a02402c4bc"
   integrity sha512-iwM3EotA9HTXqMGpQRkR/kT8OZqBbdfHTnlwcxsjSLYqY8svvsq0MuujsWCn3/vtgRmDv/PC/gKUUpoZvi5C1w==


### PR DESCRIPTION
## Description
This reverts the electron-is-dev upgrade PR that was merged in.  The 1.x series works with Electron 3, but we're stuck on Electron 2.  Without this revert, `isDev` returns `true` in the distributable version, and the app won't start since it can't find some dev dependencies.

## Motivation and Context
The app should build.

## How Has This Been Tested?
`yarn dist`

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)

## Closing issues
N/A