### PR TITLE
feat(tabs): exit client when closing last tab w/ middle mouse

### DIFF
--- a/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
+++ b/src/renderer/root/components/AuthenticatedLayout/Tabs/Tabs.js
@@ -76,6 +76,9 @@ export default class Tabs extends React.PureComponent {
     // Handle close tab using middle mouse click
     if (event.button === 1) {
       this.props.onClose(sessionId);
+      if (Object.keys(this.props.tabs).length === 1) {
+        remote.getCurrentWindow().close();
+      }
     }
   };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

<!--- Describe your changes in detail -->
## Description
exit client when hitting middle mouse on last tab


<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
## Motivation and Context
it did refresh the page instead of closing it


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment -->
## How Has This Been Tested?
manually


## Screenshots (if appropriate)



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
## Types of changes
- [ ] Chore (tests, refactors, and fixes)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)



<!-- Mark this to let us know if the docs require adjustments for this PR. -->
<!-- We have our documentation in a seperate repo, feel free to update the docs accordingly. :) -->
#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)



<!-- Put `closes #XXXX` or `fixes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
## Closing issues
Fixes #
