### PR TITLE
chore(browser): remove "bump" next to the browser

### DIFF
--- a/src/common/stylesheets/mixins.scss
+++ b/src/common/stylesheets/mixins.scss
@@ -134,7 +134,7 @@
 
 /* Track */
 ::-webkit-scrollbar-track {
-  background: none;
+  background: transparent;
 }
 
 /* Handle */

--- a/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
+++ b/src/renderer/root/components/AuthenticatedLayout/AuthenticatedLayout.scss
@@ -1,8 +1,10 @@
 $sidebar-shadow: inset -1px 0 0 $gray-3;
+$sidebar-width: 68px;
+$content-width: calc(100vw - 68px);
 
 @mixin sidebar {
   @extend %sidebarColor;
-  width: 68px;
+  width: $sidebar-width;
   mix-blend-mode: normal;
 }
 
@@ -77,11 +79,12 @@ $sidebar-shadow: inset -1px 0 0 $gray-3;
       }
 
       .content {
+        width: $content-width;
         flex: 1 1 100%;
         box-sizing: border-box;
         user-select: auto;
         cursor: auto;
-        overflow-y: scroll;
+        overflow-y: auto;
       }
     }
   }


### PR DESCRIPTION
## Description

AuthenticatedLayout's content element had a 4px bump next to it (mostly visible on scrollable content). This hardwires the content's width to the max it's allowed (viewport - sidebar) and casts overflow to auto. This is needed for internal pages (app store) that rely on native content scrolling. Scrolling in webpages inherits from the webpage itself (i.e. if the content *should* scroll, it *will* scroll.)

_Note: for some reason using $sidebar-width in $content-width doesn't work 🙂_

## Motivation and Context

Fix UI mistakes detected by @deanpress on dark/light mode switching


## How Has This Been Tested?

A/B'd with internal pages and external pages (nos.chat, nash, ...)

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/19305608/62236624-bce16100-b3cf-11e9-8c38-5ab1d31cec89.png)


## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist
- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)


#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)


## Closing issues
Fixes #
