### PR TITLE
chore(wallet): disable modal popup on already active wallet

### DIFF
--- a/src/renderer/account/components/Management/Wallet/Wallet.js
+++ b/src/renderer/account/components/Management/Wallet/Wallet.js
@@ -54,11 +54,21 @@ export default class Wallet extends React.PureComponent {
     );
   }
 
-  renderSelection = ({ account, wallet }) => (
-    <div className={styles.selection} onClick={this.showConfirm} role="button" tabIndex={0}>
-      {account.activeWalletId === wallet.walletId ? <Star /> : <EmptyStar />}
-    </div>
-  );
+  renderSelection = ({ account, wallet }) => {
+    const isActiveWallet = account.activeWalletId === wallet.walletId;
+    const activeStyle = isActiveWallet ? '' : styles.inactive;
+
+    return (
+      <div
+        className={classNames(styles.selection, activeStyle)}
+        onClick={this.showConfirm}
+        role="button"
+        tabIndex={0}
+      >
+        {isActiveWallet ? <Star /> : <EmptyStar />}
+      </div>
+    );
+  };
 
   renderInfo = ({ wallet }) => {
     const coinType = COINS[wallet.coinType];
@@ -124,8 +134,13 @@ export default class Wallet extends React.PureComponent {
   };
 
   showConfirm = () => {
-    const { account, setPassphrase, confirm } = this.props;
-    const { secretWord } = account;
+    const { account, setPassphrase, confirm, wallet } = this.props;
+    const { secretWord, activeWalletId } = account;
+    const { walletId } = wallet;
+
+    if (activeWalletId === walletId) {
+      return null;
+    }
 
     confirm(
       <div>

--- a/src/renderer/account/components/Management/Wallet/Wallet.scss
+++ b/src/renderer/account/components/Management/Wallet/Wallet.scss
@@ -19,14 +19,14 @@
     align-self: center;
     margin-right: 15px;
 
-    &:hover {
-      cursor: pointer;
-    }
-
     svg {
       width: 20px;
       height: 20px;
     }
+  }
+
+  .inactive {
+    cursor: pointer;
   }
 
   .left {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

<!--- Describe your changes in detail -->
## Description
It was possible to click the already active wallet.
This PR disables the popup from showing up and removes the hover of the already active wallet


<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
## Motivation and Context
Bad UX


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment -->
## How Has This Been Tested?



## Screenshots (if appropriate)



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
## Checklist
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)



<!-- Mark this to let us know if the docs require adjustments for this PR. -->
<!-- We have our documentation in a seperate repo, feel free to update the docs accordingly. :) -->
#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)



<!-- Put `closes #XXXX` or `fixes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
## Closing issues
Fixes #
