### PR TITLE
chore(modal): fix click outside not working when selecting dropdown

### DIFF
--- a/src/renderer/shared/components/Modal/OnClickOutside.js
+++ b/src/renderer/shared/components/Modal/OnClickOutside.js
@@ -26,9 +26,8 @@ export default class OnClickOutside extends React.PureComponent {
 
   handleClickOutside = (event) => {
     if (
-      this.wrapperRef &&
-      !this.wrapperRef.contains(event.target) &&
-      !event.target.outerHTML.toLowerCase().includes('toast')
+      !event.target.outerHTML.toLowerCase().includes('toast') &&
+      event.target.outerHTML.toLowerCase().includes('backdrop')
     ) {
       this.props.onClickOutside();
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
<!-- Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

<!--- Describe your changes in detail -->
## Description
The modal closed when clicking on a dropdown due to it being a portal and thus being "outside" of the modal


<!--- Why is this change required? What problem does it solve? -->
<!--- Describe the current and new situation/behavior --->
## Motivation and Context



<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment -->
## How Has This Been Tested?



## Screenshots (if appropriate)



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
## Types of changes
- [x] Chore (tests, refactors, and fixes)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
## Checklist
- [ ] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** guidelines and confirm that my code follows the code style of this project.
- [ ] Tests for the changes have been added (for bug fixes/features)



<!-- Mark this to let us know if the docs require adjustments for this PR. -->
<!-- We have our documentation in a seperate repo, feel free to update the docs accordingly. :) -->
#### Documentation
- [ ] Docs need to be added/updated (for bug fixes/features)



<!-- Put `closes #XXXX` or `fixes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
## Closing issues
Fixes #
